### PR TITLE
Port locking

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,6 @@
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-annotations</artifactId>
         <version>${spotbugs.version}</version>
-        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
@@ -70,7 +69,6 @@
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
         <version>${logback.version}</version>
-        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>
@@ -84,6 +82,14 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
 
   <build>
     <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
   <modules>
     <module>tools</module>
     <module>test-tools</module>
+    <module>port-locking</module>
   </modules>
 
   <dependencyManagement>
@@ -79,6 +80,11 @@
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>${junit.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>2.23.4</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/port-locking/pom.xml
+++ b/port-locking/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright Terracotta, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.terracotta</groupId>
+    <artifactId>terracotta-utilities-parent</artifactId>
+    <version>0.0-SNAPSHOT</version>
+    <relativePath>..</relativePath>
+  </parent>
+
+  <groupId>org.terracotta.utilities</groupId>
+  <artifactId>port-locking</artifactId>
+  <name>Terracotta Utilities Port Locking</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.23.4</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/port-locking/src/main/java/org/terracotta/port_locking/EmptyPortLock.java
+++ b/port-locking/src/main/java/org/terracotta/port_locking/EmptyPortLock.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.port_locking;
+
+public class EmptyPortLock implements PortLock {
+  private int port;
+
+  EmptyPortLock(int port) {
+    this.port = port;
+  }
+
+  @Override
+  public int getPort() {
+    return port;
+  }
+
+  @Override
+  public void close() {
+  }
+}

--- a/port-locking/src/main/java/org/terracotta/port_locking/GlobalFilePortLock.java
+++ b/port-locking/src/main/java/org/terracotta/port_locking/GlobalFilePortLock.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.port_locking;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.channels.Channel;
+import java.nio.channels.FileLock;
+
+public class GlobalFilePortLock implements PortLock {
+  private final int port;
+  private final RandomAccessFile file;
+  private final Channel channel;
+  private final FileLock lock;
+
+  GlobalFilePortLock(int port, RandomAccessFile file, Channel channel, FileLock lock) {
+    this.port = port;
+    this.file = file;
+    this.channel = channel;
+    this.lock = lock;
+  }
+
+  @Override
+  public int getPort() {
+    return port;
+  }
+
+  @Override
+  public void close() {
+    PortLockingException closeError = new PortLockingException("Failed to unlock during close");
+
+    try {
+      lock.close();
+    } catch (IOException e) {
+      closeError.addSuppressed(e);
+    }
+
+    try {
+      channel.close();
+    } catch (IOException e) {
+      closeError.addSuppressed(e);
+    }
+
+    try {
+      file.close();
+    } catch (IOException e) {
+      closeError.addSuppressed(e);
+    }
+
+    if (closeError.getSuppressed().length > 0) {
+      throw closeError;
+    }
+  }
+}

--- a/port-locking/src/main/java/org/terracotta/port_locking/GlobalFilePortLocker.java
+++ b/port-locking/src/main/java/org/terracotta/port_locking/GlobalFilePortLocker.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.port_locking;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
+
+import static java.nio.file.attribute.PosixFilePermissions.asFileAttribute;
+import static java.nio.file.attribute.PosixFilePermissions.fromString;
+
+public class GlobalFilePortLocker implements PortLocker {
+  private static final Logger LOGGER = LoggerFactory.getLogger(GlobalFilePortLocker.class);
+  private static final String TEMP_DIRECTORY_PROPERTY = "java.io.tmpdir";
+  private static final String PORT_LOCK_FILENAME = "tc-port-lock";
+  private static final Set<PosixFilePermission> PERMISSIONS = fromString("rw-rw-rw-");
+
+  private final File portLockFile;
+
+  public GlobalFilePortLocker() {
+    String tempDirectory = System.getProperty(TEMP_DIRECTORY_PROPERTY);
+
+    if (tempDirectory == null) {
+      throw new PortLockingException("Unable to find the OS temp directory. This is platform dependent, but can be affected by system properties.");
+    }
+
+    Path path = Paths.get(tempDirectory);
+    Path portLockFilePath = path.resolve(PORT_LOCK_FILENAME);
+
+    try {
+      portLockFile = createOrReuse(portLockFilePath);
+    } catch (IOException e) {
+      throw new PortLockingException("Failed to create port lock file: " + portLockFilePath, e);
+    }
+  }
+
+  @Override
+  public PortLock tryLockPort(int port) {
+    try {
+      RandomAccessFile file = new RandomAccessFile(portLockFile, "rw");
+      FileChannel channel = file.getChannel();
+      FileLock fileLock = channel.tryLock(port, 1, false);
+
+      if (fileLock == null) {
+        try {
+          channel.close();
+        } finally {
+          file.close();
+        }
+        return null;
+      }
+
+      return new GlobalFilePortLock(port, file, channel, fileLock);
+    } catch (IOException e) {
+      throw new PortLockingException("Error while trying to lock port", e);
+    }
+  }
+
+  private static File createOrReuse(Path portLockFilePath) throws IOException {
+    File file;
+    try {
+      try {
+        file = Files.createFile(portLockFilePath, asFileAttribute(PERMISSIONS)).toFile();
+      } catch (UnsupportedOperationException e) {
+        // in case we cannot atomically create and set these permissions / rwx not supported we retry to create normally
+        file = Files.createFile(portLockFilePath).toFile();
+      }
+      LOGGER.info("Created port lock file: {}", file.getAbsolutePath());
+    } catch (FileAlreadyExistsException e) {
+      if (!Files.isReadable(portLockFilePath)) {
+        throw new PortLockingException("File is not readable: " + portLockFilePath, e);
+      }
+      if (!Files.isWritable(portLockFilePath)) {
+        throw new PortLockingException("File is not writable: " + portLockFilePath, e);
+      }
+      file = portLockFilePath.toFile();
+      LOGGER.info("Using existing port lock file: {}", file.getAbsolutePath());
+    }
+    return file;
+  }
+}

--- a/port-locking/src/main/java/org/terracotta/port_locking/LocalPortLocker.java
+++ b/port-locking/src/main/java/org/terracotta/port_locking/LocalPortLocker.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.port_locking;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class LocalPortLocker implements PortLocker {
+  private static final Set<Integer> localPortLocks = ConcurrentHashMap.newKeySet();
+
+  @Override
+  public PortLock tryLockPort(int port) {
+    boolean added = localPortLocks.add(port);
+
+    if (!added) {
+      return null;
+    }
+
+    return new LocalPortLock(port);
+  }
+
+  private static class LocalPortLock implements PortLock {
+    private final int port;
+
+    LocalPortLock(int port) {
+      this.port = port;
+    }
+
+    @Override
+    public int getPort() {
+      return port;
+    }
+
+    @Override
+    public void close() {
+      boolean removed = localPortLocks.remove(port);
+
+      if (!removed) {
+        throw new AssertionError("Attempted to remove local lock on port " + port + " but it was not present");
+      }
+    }
+  }
+}

--- a/port-locking/src/main/java/org/terracotta/port_locking/LockingPortChooser.java
+++ b/port-locking/src/main/java/org/terracotta/port_locking/LockingPortChooser.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.port_locking;
+
+public class LockingPortChooser {
+  private final PortAllocator portAllocator;
+  private final PortLocker portLocker;
+
+  public LockingPortChooser(PortAllocator portAllocator, PortLocker portLocker) {
+    this.portAllocator = portAllocator;
+    this.portLocker = portLocker;
+  }
+
+  public synchronized MuxPortLock choosePorts(int portCount) {
+    while (true) {
+      MuxPortLock muxPortLock = tryChoosePorts(portCount);
+
+      if (muxPortLock != null) {
+        return muxPortLock;
+      }
+    }
+  }
+
+  private MuxPortLock tryChoosePorts(int portCount) {
+    int portBase = portAllocator.allocatePorts(portCount);
+
+    MuxPortLock muxPortLock = new MuxPortLock(portBase);
+
+    for (int i = 0; i < portCount; i++) {
+      int port = portBase + i;
+
+      PortLock portLock = portLocker.tryLockPort(port);
+
+      if (portLock == null) {
+        muxPortLock.close();
+        return null;
+      }
+
+      muxPortLock.addPortLock(portLock);
+    }
+
+    return muxPortLock;
+  }
+}

--- a/port-locking/src/main/java/org/terracotta/port_locking/LockingPortChoosers.java
+++ b/port-locking/src/main/java/org/terracotta/port_locking/LockingPortChoosers.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.port_locking;
+
+import java.security.SecureRandom;
+
+public class LockingPortChoosers {
+
+  private static final LockingPortChooser SINGLETON = new LockingPortChooser(
+      new RandomPortAllocator(new SecureRandom()),
+      new MuxPortLocker(
+          new LocalPortLocker(),
+          new SocketPortLocker(),
+          new GlobalFilePortLocker()
+      )
+  );
+
+  /**
+   * Returns a LockingPortChooser that works by acquiring a lock for a port by creating a FileLock on the corresponding
+   * byte in an agreed upon file. The FileLocks are created by GlobalFilePortLocker.
+   * Because FileLocks are held by the whole JVM, we also need a system of locking within this JVM, which is handled by
+   * the LocalPortLocker.
+   * In the SocketPortLocker, we also check that the socket is available.
+   *
+   * @return the LockingPortChooser that can generate ports that should be free to use as long as the lock is held
+   */
+  public static LockingPortChooser getFileLockingPortChooser() {
+    return SINGLETON;
+  }
+}

--- a/port-locking/src/main/java/org/terracotta/port_locking/MuxPortLock.java
+++ b/port-locking/src/main/java/org/terracotta/port_locking/MuxPortLock.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.port_locking;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class MuxPortLock implements PortLock {
+  private final int port;
+  private final List<PortLock> portLocks;
+
+  MuxPortLock(int port) {
+    this.port = port;
+    this.portLocks = new ArrayList<>();
+  }
+
+  private MuxPortLock(int port, List<PortLock> portLocks1, List<PortLock> portLocks2) {
+    this.port = port;
+    this.portLocks = new ArrayList<>(portLocks1.size() + portLocks2.size());
+    portLocks.addAll(portLocks1);
+    portLocks.addAll(portLocks2);
+  }
+
+  void addPortLock(PortLock portLock) {
+    portLocks.add(portLock);
+  }
+
+  public MuxPortLock combine(MuxPortLock other) {
+    return new MuxPortLock(port, portLocks, other.portLocks);
+  }
+
+  @Override
+  public int getPort() {
+    return port;
+  }
+
+  @Override
+  public void close() {
+    PortLockingException closeError = new PortLockingException("Error closing MuxPortLock");
+
+    Collections.reverse(portLocks);
+
+    portLocks.forEach(portLock -> {
+      try {
+        portLock.close();
+      } catch (PortLockingException e) {
+        closeError.addSuppressed(e);
+      }
+    });
+
+    portLocks.clear();
+
+    if (closeError.getSuppressed().length > 0) {
+      throw closeError;
+    }
+  }
+}

--- a/port-locking/src/main/java/org/terracotta/port_locking/MuxPortLocker.java
+++ b/port-locking/src/main/java/org/terracotta/port_locking/MuxPortLocker.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.port_locking;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class MuxPortLocker implements PortLocker {
+  private List<PortLocker> portLockers;
+
+  public MuxPortLocker(PortLocker... portLockers) {
+    this(Arrays.asList(portLockers));
+  }
+
+  private MuxPortLocker(List<PortLocker> portLockers) {
+    this.portLockers = portLockers;
+  }
+
+  @Override
+  public PortLock tryLockPort(int port) {
+    MuxPortLock muxPortLock = new MuxPortLock(port);
+
+    for (PortLocker portLocker : portLockers) {
+      PortLock portLock = portLocker.tryLockPort(port);
+
+      if (portLock == null) {
+        muxPortLock.close();
+        return null;
+      }
+
+      muxPortLock.addPortLock(portLock);
+    }
+
+    return muxPortLock;
+  }
+}

--- a/port-locking/src/main/java/org/terracotta/port_locking/PortAllocator.java
+++ b/port-locking/src/main/java/org/terracotta/port_locking/PortAllocator.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.port_locking;
+
+public interface PortAllocator {
+  /**
+   * Get portCount consecutive ports
+   *
+   * @param portCount the number of ports to allocate
+   * @return the lowest port
+   */
+  int allocatePorts(int portCount);
+}

--- a/port-locking/src/main/java/org/terracotta/port_locking/PortLock.java
+++ b/port-locking/src/main/java/org/terracotta/port_locking/PortLock.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.port_locking;
+
+import java.io.Closeable;
+
+public interface PortLock extends Closeable {
+  int getPort();
+
+  @Override
+  void close();
+}

--- a/port-locking/src/main/java/org/terracotta/port_locking/PortLocker.java
+++ b/port-locking/src/main/java/org/terracotta/port_locking/PortLocker.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.port_locking;
+
+public interface PortLocker {
+  PortLock tryLockPort(int port);
+}

--- a/port-locking/src/main/java/org/terracotta/port_locking/PortLockingException.java
+++ b/port-locking/src/main/java/org/terracotta/port_locking/PortLockingException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.port_locking;
+
+import java.io.IOException;
+
+public class PortLockingException extends RuntimeException {
+  private static final long serialVersionUID = 1L;
+
+  PortLockingException(String message) {
+    super(message);
+  }
+
+  PortLockingException(String message, IOException cause) {
+    super(message, cause);
+  }
+}

--- a/port-locking/src/main/java/org/terracotta/port_locking/PortLockingRule.java
+++ b/port-locking/src/main/java/org/terracotta/port_locking/PortLockingRule.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.port_locking;
+
+import org.junit.rules.ExternalResource;
+
+import java.util.stream.IntStream;
+
+/**
+ * @author Mathieu Carbou
+ */
+public class PortLockingRule extends ExternalResource {
+
+  private static final LockingPortChooser LOCKING_PORT_CHOOSER = LockingPortChoosers.getFileLockingPortChooser();
+
+  private final int count;
+
+  private MuxPortLock portLock;
+  private int[] ports = new int[0];
+
+  public PortLockingRule(int count) {
+    this.count = count;
+  }
+
+  public int getPort() {
+    return getPorts()[0];
+  }
+
+  public int[] getPorts() {
+    return ports.clone();
+  }
+
+  @Override
+  protected void before() {
+    if (count > 0) {
+      this.portLock = LOCKING_PORT_CHOOSER.choosePorts(count);
+      this.ports = IntStream.range(portLock.getPort(), portLock.getPort() + count).toArray();
+    } else {
+      this.ports = new int[0];
+    }
+  }
+
+  @Override
+  protected void after() {
+    if (portLock != null) {
+      portLock.close();
+    }
+  }
+}

--- a/port-locking/src/main/java/org/terracotta/port_locking/RandomPortAllocator.java
+++ b/port-locking/src/main/java/org/terracotta/port_locking/RandomPortAllocator.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.port_locking;
+
+import java.util.Random;
+
+public class RandomPortAllocator implements PortAllocator {
+  private static final int LOWEST_PORT_INCLUSIVE = 1024;
+  private static final int HIGHEST_PORT_INCLUSIVE = 32767;
+
+  private final Random random;
+
+  public RandomPortAllocator(Random random) {
+    this.random = random;
+  }
+
+  @Override
+  public int allocatePorts(int portCount) {
+    int highestPortAdjustment = portCount - 1;
+    return getRandomIntInRange(LOWEST_PORT_INCLUSIVE, HIGHEST_PORT_INCLUSIVE - highestPortAdjustment);
+  }
+
+  private int getRandomIntInRange(int min, int max) {
+    return random.nextInt((max - min) + 1) + min;
+  }
+}

--- a/port-locking/src/main/java/org/terracotta/port_locking/SocketPortLocker.java
+++ b/port-locking/src/main/java/org/terracotta/port_locking/SocketPortLocker.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.port_locking;
+
+import java.io.IOException;
+import java.net.BindException;
+import java.net.ServerSocket;
+
+public class SocketPortLocker implements PortLocker {
+  @Override
+  public PortLock tryLockPort(int port) {
+    ServerSocket serverSocket = null;
+
+    try {
+      serverSocket = new ServerSocket(port);
+      return new EmptyPortLock(port);
+    } catch (BindException be) {
+      return null;
+    } catch (IOException e) {
+      throw new PortLockingException("Error detecting whether port " + port + " is available to bind", e);
+    } finally {
+      if (serverSocket != null) {
+        try {
+          serverSocket.close();
+        } catch (IOException e) {
+          throw new PortLockingException("Failed to close socket", e);
+        }
+      }
+    }
+  }
+}

--- a/port-locking/src/test/java/org/terracotta/port_locking/EmptyPortLockTest.java
+++ b/port-locking/src/test/java/org/terracotta/port_locking/EmptyPortLockTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.port_locking;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class EmptyPortLockTest {
+  @Test
+  public void getPort() {
+    EmptyPortLock lock = new EmptyPortLock(1);
+    assertEquals(1, lock.getPort());
+  }
+}

--- a/port-locking/src/test/java/org/terracotta/port_locking/GlobalFilePortLockTest.java
+++ b/port-locking/src/test/java/org/terracotta/port_locking/GlobalFilePortLockTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.port_locking;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.channels.Channel;
+import java.nio.channels.FileLock;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GlobalFilePortLockTest {
+  @Mock
+  private RandomAccessFile file;
+
+  @Mock
+  private Channel channel;
+
+  @Mock
+  private FileLock lock;
+
+  @Test
+  public void happyPath() throws Exception {
+    PortLock portLock = new GlobalFilePortLock(1, file, channel, lock);
+    assertEquals(1, portLock.getPort());
+    portLock.close();
+    verify(file).close();
+    verify(channel).close();
+    verify(lock).close();
+  }
+
+  @Test
+  public void closesThrow() throws Exception {
+    doThrow(IOException.class).when(file).close();
+    doThrow(IOException.class).when(channel).close();
+    doThrow(IOException.class).when(lock).close();
+    PortLock portLock = new GlobalFilePortLock(1, file, channel, lock);
+    assertEquals(1, portLock.getPort());
+    try {
+      portLock.close();
+      fail("Expected PortLockingException");
+    } catch (PortLockingException e) {
+      // Expected
+    }
+    verify(file).close();
+    verify(channel).close();
+    verify(lock).close();
+  }
+}

--- a/port-locking/src/test/java/org/terracotta/port_locking/GlobalFilePortLockerTest.java
+++ b/port-locking/src/test/java/org/terracotta/port_locking/GlobalFilePortLockerTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.port_locking;
+
+import org.junit.Test;
+
+public class GlobalFilePortLockerTest {
+  @Test
+  public void canTryLock() {
+    GlobalFilePortLocker locker = new GlobalFilePortLocker();
+
+    PortLock portLock1 = locker.tryLockPort(2000);
+    if (portLock1 != null) {
+      portLock1.close();
+    }
+
+    PortLock portLock2 = locker.tryLockPort(2000);
+    if (portLock2 != null) {
+      portLock2.close();
+    }
+  }
+}

--- a/port-locking/src/test/java/org/terracotta/port_locking/LocalPortLockerTest.java
+++ b/port-locking/src/test/java/org/terracotta/port_locking/LocalPortLockerTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.port_locking;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class LocalPortLockerTest {
+  @Test
+  public void portLocking() {
+    LocalPortLocker locker = new LocalPortLocker();
+    PortLock portLock1 = locker.tryLockPort(1);
+    assertNotNull(portLock1);
+    assertEquals(1, portLock1.getPort());
+
+    PortLock portLock2 = locker.tryLockPort(1);
+    assertNull(portLock2);
+
+    PortLock portLock3 = locker.tryLockPort(2);
+    assertNotNull(portLock3);
+    assertEquals(2, portLock3.getPort());
+
+    portLock1.close();
+    portLock3.close();
+
+    PortLock portLock4 = locker.tryLockPort(1);
+    assertNotNull(portLock4);
+    assertEquals(1, portLock4.getPort());
+
+    portLock4.close();
+  }
+}

--- a/port-locking/src/test/java/org/terracotta/port_locking/LockingPortChooserTest.java
+++ b/port-locking/src/test/java/org/terracotta/port_locking/LockingPortChooserTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.port_locking;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+
+import java.util.BitSet;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LockingPortChooserTest {
+  @Mock
+  private PortAllocator portAllocator;
+
+  @Mock
+  private PortLocker portLocker;
+
+  private BitSet locks = new BitSet(16);
+  private LockingPortChooser portChooser;
+
+  @Before
+  public void before() {
+    portChooser = new LockingPortChooser(portAllocator, portLocker);
+    when(portLocker.tryLockPort(anyInt())).thenAnswer((Answer<PortLock>) invocation -> {
+      int port = invocation.getArgument(0);
+      if (locks.get(port)) {
+        return null;
+      }
+
+      locks.set(port);
+
+      return new TestPortLock(port);
+    });
+  }
+
+  @Test
+  public void happyPath() {
+    when(portAllocator.allocatePorts(4)).thenReturn(2, 6);
+
+    try (MuxPortLock portLock = portChooser.choosePorts(4)) {
+      assertEquals(2, portLock.getPort());
+    }
+
+    try (MuxPortLock portLock = portChooser.choosePorts(4)) {
+      assertEquals(6, portLock.getPort());
+    }
+  }
+
+  @Test
+  public void reattempt() {
+    when(portAllocator.allocatePorts(4)).thenReturn(2, 2, 6);
+
+    try (
+        MuxPortLock portLock1 = portChooser.choosePorts(4);
+        MuxPortLock portLock2 = portChooser.choosePorts(4)
+    ) {
+      assertEquals(2, portLock1.getPort());
+      assertEquals(6, portLock2.getPort());
+    }
+  }
+
+  @Test
+  public void overlap() {
+    when(portAllocator.allocatePorts(4)).thenReturn(2, 0, 6, 0);
+
+    try (
+        MuxPortLock portLock1 = portChooser.choosePorts(4);
+        MuxPortLock portLock2 = portChooser.choosePorts(4)
+    ) {
+      assertEquals(2, portLock1.getPort());
+      assertEquals(6, portLock2.getPort());
+    }
+
+    try (MuxPortLock portLock = portChooser.choosePorts(4)) {
+      assertEquals(0, portLock.getPort());
+    }
+  }
+
+  private class TestPortLock implements PortLock {
+    private final int port;
+
+    TestPortLock(int port) {
+      this.port = port;
+    }
+
+    @Override
+    public int getPort() {
+      return port;
+    }
+
+    @Override
+    public void close() {
+      if (!locks.get(port)) {
+        throw new AssertionError("Lock not locked");
+      }
+
+      locks.clear(port);
+    }
+  }
+}

--- a/port-locking/src/test/java/org/terracotta/port_locking/MuxPortLockTest.java
+++ b/port-locking/src/test/java/org/terracotta/port_locking/MuxPortLockTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.port_locking;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MuxPortLockTest {
+  @Mock
+  private PortLock lock1;
+
+  @Mock
+  private PortLock lock2;
+
+  @Test
+  public void getPort() {
+    MuxPortLock lock = new MuxPortLock(1);
+    assertEquals(1, lock.getPort());
+  }
+
+  @Test
+  public void closeEmpty() {
+    MuxPortLock lock = new MuxPortLock(1);
+
+    lock.addPortLock(lock1);
+    lock.addPortLock(lock2);
+
+    lock.close();
+
+    verify(lock1).close();
+    verify(lock2).close();
+  }
+
+  @Test
+  public void closeWithThrowing() {
+    doThrow(PortLockingException.class).when(lock1).close();
+    doThrow(PortLockingException.class).when(lock2).close();
+
+    MuxPortLock lock = new MuxPortLock(1);
+
+    lock.addPortLock(lock1);
+    lock.addPortLock(lock2);
+
+    try {
+      lock.close();
+      fail("Expected PortLockingException");
+    } catch (PortLockingException e) {
+      // Expected
+    }
+
+    verify(lock1).close();
+    verify(lock2).close();
+  }
+}

--- a/port-locking/src/test/java/org/terracotta/port_locking/MuxPortLockerTest.java
+++ b/port-locking/src/test/java/org/terracotta/port_locking/MuxPortLockerTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.port_locking;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MuxPortLockerTest {
+  @Mock
+  private PortLocker locker1;
+
+  @Mock
+  private PortLocker locker2;
+
+  @Mock
+  private PortLock lock1;
+
+  @Mock
+  private PortLock lock2;
+
+  @Test
+  public void usesMultipleLockers() {
+    when(locker1.tryLockPort(1)).thenReturn(lock1);
+    when(locker2.tryLockPort(1)).thenReturn(lock2);
+
+    PortLocker locker = new MuxPortLocker(locker1, locker2);
+
+    PortLock portLock = locker.tryLockPort(1);
+    assertNotNull(portLock);
+    assertEquals(1, portLock.getPort());
+
+    portLock.close();
+
+    verify(lock1).close();
+    verify(lock2).close();
+  }
+
+  @Test
+  public void stopAtFirstLockFailure() {
+    PortLocker locker = new MuxPortLocker(locker1, locker2);
+
+    PortLock portLock = locker.tryLockPort(1);
+    assertNull(portLock);
+  }
+
+  @Test
+  public void stopAtSecondLockFailure() {
+    when(locker1.tryLockPort(1)).thenReturn(lock1);
+
+    PortLocker locker = new MuxPortLocker(locker1, locker2);
+
+    PortLock portLock = locker.tryLockPort(1);
+    assertNull(portLock);
+
+    verify(lock1).close();
+  }
+}

--- a/port-locking/src/test/java/org/terracotta/port_locking/RandomPortAllocatorTest.java
+++ b/port-locking/src/test/java/org/terracotta/port_locking/RandomPortAllocatorTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.port_locking;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.security.SecureRandom;
+import java.util.Random;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RandomPortAllocatorTest {
+  @Test
+  public void withinRange() {
+    int seed = new SecureRandom().nextInt();
+    PortAllocator allocator = new RandomPortAllocator(new Random(seed));
+
+    for (int i = 0; i < 10_000; i++) {
+      int portBase = allocator.allocatePorts(4);
+      if (portBase < 1024 || portBase > 32764) {
+        throw new AssertionError("portBase outside range: " + portBase + " seed: " + seed);
+      }
+    }
+  }
+}

--- a/port-locking/src/test/java/org/terracotta/port_locking/SocketPortLockerTest.java
+++ b/port-locking/src/test/java/org/terracotta/port_locking/SocketPortLockerTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.port_locking;
+
+import org.junit.Test;
+
+public class SocketPortLockerTest {
+  @Test
+  public void tryLock() {
+    PortLocker locker = new SocketPortLocker();
+    PortLock portLock = locker.tryLockPort(2000);
+    if (portLock != null) {
+      portLock.close();
+    }
+  }
+}

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -45,10 +45,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.github.spotbugs</groupId>
-      <artifactId>spotbugs-annotations</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.terracotta</groupId>
       <artifactId>terracotta-utilities-test-tools</artifactId>
       <version>${project.version}</version>
@@ -57,6 +53,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
Moving port locking mechanism from tc-ee (and then tc-platform) to this project so that it can be used in angela, ehcache, galvan, tc-platform, core, etc.

No class change, no artifactId change. 

Only change is the groupId (to not conflict with existing released version).

BTW, as a side note, all the modules of this repo should have the same groupId `<groupId>org.terracotta.utilities</groupId>` to organize better the org/terracotta folder in the maven repo (have a look at your `~/.m2/repository/org/terracotta`)... I did it for this module, didn't change the existing ones... But we should I think.

This PR is based on #7