### PR TITLE
Proposal for a better exception matcher

### DIFF
--- a/test-tools/src/main/java/org/terracotta/utilities/test/matchers/ExceptionMatcher.java
+++ b/test-tools/src/main/java/org/terracotta/utilities/test/matchers/ExceptionMatcher.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2020 Terracotta, Inc., a Software AG company.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.utilities.test.matchers;
+
+import org.hamcrest.CustomMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+import java.util.Map;
+import java.util.WeakHashMap;
+
+import static java.util.Objects.requireNonNull;
+import static org.hamcrest.CoreMatchers.instanceOf;
+
+public class ExceptionMatcher extends TypeSafeMatcher<ExceptionMatcher.Closure> {
+
+  private static final CustomMatcher<String> ANY_MESSAGE = new CustomMatcher<String>("ANY MESSAGE") {
+    @Override
+    public boolean matches(Object item) {
+      return true;
+    }
+  };
+  private static final CustomMatcher<? super Class<? extends Throwable>> ANY_CAUSE = new CustomMatcher<Class<? extends Throwable>>("ANY CAUSE") {
+    @Override
+    public boolean matches(Object item) {
+      return true;
+    }
+  };
+
+  private final Matcher<? super Class<? extends Throwable>> typeMatcher;
+  private Matcher<? super String> messageMatcher = ANY_MESSAGE;
+  private Matcher<? super Class<? extends Throwable>> causeMatcher = ANY_CAUSE;
+
+  private Throwable failure;
+
+  private ExceptionMatcher(Matcher<? super Class<? extends Throwable>> typeMatcher) {
+    this.typeMatcher = requireNonNull(typeMatcher);
+  }
+
+  @Override
+  public void describeTo(Description description) {
+    typeMatcher.describeTo(description);
+    if (messageMatcher != ANY_MESSAGE) {
+      description.appendText(" with message ");
+      messageMatcher.describeTo(description);
+    }
+    if (causeMatcher != ANY_CAUSE) {
+      description.appendText(" with cause ");
+      causeMatcher.describeTo(description);
+    }
+  }
+
+  @Override
+  protected boolean matchesSafely(Closure item) {
+    try {
+      item.run();
+      return false;
+    } catch (Throwable e) {
+      failure = e;
+      return typeMatcher.matches(e) && messageMatcher.matches(e.getMessage()) && causeMatcher.matches(e.getCause());
+    }
+  }
+
+  @Override
+  protected void describeMismatchSafely(Closure item, Description mismatchDescription) {
+    if (failure != null) {
+      super.describeMismatchSafely(new ToStringClosure(failure.toString()), mismatchDescription);
+    } else {
+      super.describeMismatchSafely(new ToStringClosure("no exception was thrown"), mismatchDescription);
+    }
+  }
+
+  public static ExceptionMatcher throwing() {
+    return throwing(instanceOf(Throwable.class));
+  }
+
+  public static ExceptionMatcher throwing(Matcher<? super Class<? extends Throwable>> err) {
+    return new ExceptionMatcher(err);
+  }
+
+  public ExceptionMatcher andMessage(Matcher<? super String> messageMatcher) {
+    this.messageMatcher = requireNonNull(messageMatcher);
+    return this;
+  }
+
+  public ExceptionMatcher andCause(Matcher<? super Class<? extends Throwable>> causeMatcher) {
+    this.causeMatcher = requireNonNull(causeMatcher);
+    return this;
+  }
+
+  private static class ToStringClosure implements Closure {
+    private final String toString;
+
+    public ToStringClosure(String toString) {
+      this.toString = toString;
+    }
+
+    @Override
+    public void run() {
+    }
+
+    @Override
+    public String toString() {
+      return toString;
+    }
+  }
+
+  @FunctionalInterface
+  public interface Closure {
+    void run() throws Throwable;
+  }
+
+}

--- a/test-tools/src/main/java/org/terracotta/utilities/test/matchers/Matchers.java
+++ b/test-tools/src/main/java/org/terracotta/utilities/test/matchers/Matchers.java
@@ -51,4 +51,12 @@ public class Matchers {
   public static <T> Matcher<Optional<T>> optionalThat(Matcher<? super T> matcher) {
     return OptionalMatcher.optionalThat(matcher);
   }
+
+  public static ExceptionMatcher throwing() {
+    return ExceptionMatcher.throwing();
+  }
+
+  public static ExceptionMatcher throwing(Matcher<? super Class<? extends Throwable>> err) {
+    return ExceptionMatcher.throwing(err);
+  }
 }

--- a/test-tools/src/test/java/org/terracotta/utilities/test/matchers/ExceptionMatcherTest.java
+++ b/test-tools/src/test/java/org/terracotta/utilities/test/matchers/ExceptionMatcherTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Terracotta, Inc., a Software AG company.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.utilities.test.matchers;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.stringContainsInOrder;
+import static org.terracotta.utilities.test.matchers.Matchers.throwing;
+
+public class ExceptionMatcherTest {
+  @Test
+  public void examples() {
+    assertThat(() -> {throw new IllegalArgumentException();}, is(throwing()));
+
+    assertThat(() -> {throw new IllegalArgumentException();}, is(throwing(instanceOf(IllegalArgumentException.class))));
+
+    assertThat(
+        () -> {throw new IllegalArgumentException("foo");},
+        is(throwing(instanceOf(IllegalArgumentException.class)).andMessage(is(equalTo("foo")))));
+
+    assertThat(
+        () -> {throw new IllegalStateException(new IllegalArgumentException("bar"));},
+        is(throwing(instanceOf(IllegalStateException.class))
+            .andCause(is(instanceOf(IllegalArgumentException.class)))
+            .andMessage(stringContainsInOrder("java.lang.IllegalArgumentException", "bar"))));
+
+    assertThat(
+        this::aThrowingMethod,
+        is(throwing(instanceOf(UnsupportedOperationException.class))));
+  }
+
+  void aThrowingMethod() {
+    throw new UnsupportedOperationException();
+  }
+}


### PR DESCRIPTION
This is the exception matchers we are using a cross all tc-platform code and EE (dynamic config).

It does not enforce a redefinition of the hamcrest `assertThat` ans sticks to the hamcrest way of doing things by extending the framework with statically imported matchers.

Also, the use of a task that is returning something is bad since it is not possible to easily test some methods that do not return something.

BAD:

```
    assertThrows(() -> {
      aThrowingMethod();
      return null; // BAD !
    }, causedBy(instanceOf(UnsupportedOperationException.class)));
```

What is should be:

```
    assertThat(
        this::aThrowingMethod,
        is(throwing(instanceOf(UnsupportedOperationException.class))));```
```

Some examples with the new matcher:

```
    assertThat(() -> {throw new IllegalArgumentException();}, is(throwing()));

    assertThat(() -> {throw new IllegalArgumentException();}, is(throwing(instanceOf(IllegalArgumentException.class))));

    assertThat(
        () -> {throw new IllegalArgumentException("foo");},
        is(throwing(instanceOf(IllegalArgumentException.class)).andMessage(is(equalTo("foo")))));

    assertThat(
        () -> {throw new IllegalStateException(new IllegalArgumentException("bar"));},
        is(throwing(instanceOf(IllegalStateException.class))
            .andCause(is(instanceOf(IllegalArgumentException.class)))
            .andMessage(stringContainsInOrder("java.lang.IllegalArgumentException", "bar"))));
  }
```