### PR TITLE
Correct Files.relocate and Files.rename behavior

### DIFF
--- a/port-chooser/src/main/java/org/terracotta/utilities/test/net/SystemLevelLocker.java
+++ b/port-chooser/src/main/java/org/terracotta/utilities/test/net/SystemLevelLocker.java
@@ -92,7 +92,7 @@ class SystemLevelLocker {
     int port = requireNonNull(portRef, "portRef").port();
     try {
       if (openChannel == null) {
-        LOGGER.trace("Opening system-level port lock file {}", lockFilePath);
+        LOGGER.info("Opening system-level port lock file {}", lockFilePath);
         openChannel = FileChannel.open(lockFilePath, StandardOpenOption.WRITE, StandardOpenOption.READ);
       }
 
@@ -100,7 +100,7 @@ class SystemLevelLocker {
       if (fileLock != null) {
         outstandingLocks++;
         portRef.onClose(() -> release(port, fileLock));
-        LOGGER.trace("System-level reservation obtained for port {}", port);
+        LOGGER.info("Port {} reserved (system-level)", port);
         return true;
       } else {
         // Locked by another process
@@ -127,8 +127,9 @@ class SystemLevelLocker {
 
     try {
       lock.release();
-      LOGGER.trace("Released system-level reservation for port {}", port);
+      LOGGER.info("Port {} released (system-level)", port);
     } catch (ClosedChannelException ignored) {
+      LOGGER.info("Port {} already released (system-level): channel closed", port);
     } catch (IOException e) {
       LOGGER.warn(String.format("Error while releasing lock against \"%s\" for port %s",
           lockFilePath, port), e);
@@ -144,7 +145,7 @@ class SystemLevelLocker {
   private void closeChannelIfUnused() {
     if (openChannel != null && outstandingLocks == 0) {
       try {
-        LOGGER.trace("Closing system-level port lock file {}", lockFilePath);
+        LOGGER.info("Closing system-level port lock file {}", lockFilePath);
         openChannel.close();
       } catch (IOException e) {
         LOGGER.warn(String.format("Failed to close \"%s\"", lockFilePath), e);

--- a/test-tools/src/test/java/org/terracotta/utilities/test/DiagnosticsTest.java
+++ b/test-tools/src/test/java/org/terracotta/utilities/test/DiagnosticsTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2020 Terracotta, Inc., a Software AG company.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.utilities.test;
+
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.function.Consumer;
+
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsInRelativeOrder;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.*;
+
+/**
+ * Rudimentary tests for {@link Diagnostics} methods.
+ */
+public class DiagnosticsTest {
+
+  @Test
+  public void testDumpThreads() throws Exception {
+
+    CyclicBarrier barrier = new CyclicBarrier(2);
+    try {
+      Thread blockedThread = new Thread(() -> {
+        try {
+          barrier.await();
+        } catch (InterruptedException | BrokenBarrierException ignored) {
+        }
+      }, "Blocked Thread");
+      blockedThread.setDaemon(true);
+      blockedThread.start();
+
+      Thread terminatedThread = new Thread(() -> {}, "Terminated Thread");
+      terminatedThread.setDaemon(true);
+      terminatedThread.start();
+      terminatedThread.join();
+
+      Thread currentThread = Thread.currentThread();
+      String currentThreadName = "\"" + currentThread.getName() + "\"";
+      List<Thread> threads = Arrays.asList(blockedThread, terminatedThread, currentThread);
+
+      assertThat(perform(out -> Diagnostics.dumpThreads(threads, true, out)),
+          containsInRelativeOrder(
+              allOf(startsWith("\"Blocked Thread\""), containsString("WAITING on")),
+              allOf(startsWith("\"Terminated Thread\""), containsString("TERMINATED")),
+              allOf(startsWith(currentThreadName), containsString("RUNNABLE"))
+          ));
+
+      assertThat(perform(out -> Diagnostics.dumpThreads(threads, false, out)),
+          containsInRelativeOrder(
+              allOf(startsWith("\"Blocked Thread\""), containsString("WAITING")),
+              allOf(startsWith("\"Terminated Thread\""), containsString("TERMINATED")),
+              allOf(startsWith(currentThreadName), containsString("RUNNABLE"))
+          ));
+
+    } finally {
+      barrier.reset();
+    }
+  }
+
+  @SuppressWarnings("deprecation")
+  @Test
+  public void testGetPid() {
+    long pid = Diagnostics.getLongPid();
+    assertThat(pid, is(not(-1L)));
+    int intPid = Diagnostics.getPid();      // deprecation
+    assertThat(intPid, is((int)pid));
+  }
+
+  private List<String> perform(Consumer<PrintStream> task) {
+    try {
+      ByteArrayOutputStream byteStream = new ByteArrayOutputStream(4096);
+      try (PrintStream out = new PrintStream(byteStream, true, StandardCharsets.UTF_8.name())) {
+        task.accept(out);
+      }
+
+      try (BufferedReader reader =
+               new BufferedReader(new StringReader(byteStream.toString(StandardCharsets.UTF_8.name())))) {
+        return reader.lines().collect(toList());
+      }
+    } catch (IOException e) {
+      throw new AssertionError(e);
+    }
+  }
+}

--- a/tools/src/main/java/org/terracotta/utilities/exec/Shell.java
+++ b/tools/src/main/java/org/terracotta/utilities/exec/Shell.java
@@ -68,7 +68,12 @@ public final class Shell {
         commandLines.add(line);
       }
     }
-    int rc = process.exitValue();
+    int rc;
+    try {
+      rc = process.waitFor();
+    } catch (InterruptedException e) {
+      throw new IOException(e);
+    }
 
     if (LOGGER.isDebugEnabled()) {
       LOGGER.debug("Command: {}; rc={}", Arrays.toString(command), rc);

--- a/tools/src/main/java/org/terracotta/utilities/io/Files.java
+++ b/tools/src/main/java/org/terracotta/utilities/io/Files.java
@@ -291,7 +291,7 @@ public final class Files {
     Path resolvedTarget = origin.resolveSibling(target);
 
     retryingRenamePath(realOrigin, () -> resolvedTarget, renameTimeLimit, progressHelper);
-    return target;
+    return resolvedTarget;
   }
 
   /**

--- a/tools/src/main/java/org/terracotta/utilities/io/FilesSupport.java
+++ b/tools/src/main/java/org/terracotta/utilities/io/FilesSupport.java
@@ -287,7 +287,7 @@ class FilesSupport {
    */
   private static class PathHolder implements AutoCloseable {
     // Needs a local LOGGER to prevent issues with initialization of Files class.
-    private static final Logger LOGGER = LoggerFactory.getLogger(Files.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(PathHolder.class);
     private final Thread thread;
     private final Phaser barrier = new Phaser(2);
 

--- a/tools/src/test/java/org/terracotta/utilities/io/FilesDeleteTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/io/FilesDeleteTest.java
@@ -126,7 +126,7 @@ public class FilesDeleteTest extends FilesTestBase {
   public void testFileDeleteInTime() throws Exception {
     try (PathHolder holder = new PathHolder(topFile, Duration.ofMillis(100))) {
       holder.start();
-      Files.delete(topFile, holder.getHoldTime());
+      Files.delete(topFile, holder.getHoldTime().multipliedBy(2));
     }
     assertFalse(exists(topFile, LinkOption.NOFOLLOW_LINKS));
   }

--- a/tools/src/test/java/org/terracotta/utilities/io/FilesDeleteTreeTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/io/FilesDeleteTreeTest.java
@@ -88,7 +88,7 @@ public class FilesDeleteTreeTest extends FilesTestBase {
   public void testFileDeleteTreeInTime() throws Exception {
     try (PathHolder holder = new PathHolder(topFile, Duration.ofMillis(100))) {
       holder.start();
-      Files.deleteTree(topFile, holder.getHoldTime());
+      Files.deleteTree(topFile, holder.getHoldTime().multipliedBy(2));
     }
     assertFalse(exists(topFile, LinkOption.NOFOLLOW_LINKS));
   }

--- a/tools/src/test/java/org/terracotta/utilities/io/FilesEnvironmentTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/io/FilesEnvironmentTest.java
@@ -1,0 +1,682 @@
+/*
+ * Copyright 2020 Terracotta, Inc., a Software AG company.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.utilities.io;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.terracotta.utilities.exec.Shell;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.nio.file.Files.createDirectory;
+import static java.nio.file.Files.createFile;
+import static java.util.Collections.singleton;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
+
+/**
+ * Performs tests against {@link java.nio.file.Files} to gauge operational
+ * behaviors and requirements.
+ *
+ * <h3>Observations</h3>
+ * These observations are collected from tests in this class run in the following environments:
+ *
+ * <dl>
+ *   <dt>Windows</dt>
+ *   <dd>OS: Microsoft Windows 10 Enterprise 10.0.17763 N/A Build 17763
+ *     <br>Java Runtime: Java(TM) SE Runtime Environment (1.8.0_231-b11)
+ *     <br>Java VM: Java HotSpot(TM) 64-Bit Server VM (25.231-b11)</dd>
+ *   <dt>Linux</dt>
+ *   <dd>OS: Linux 4.4.0-17763-Microsoft #864-Microsoft Thu Nov 07 15:22:00 PST 2019
+ *     <br>Java Runtime: OpenJDK Runtime Environment (1.8.0_232-b18)
+ *     <br>Java VM: OpenJDK 64-Bit Server VM (25.232-b18)</dd>
+ *   <dt>Mac OS X</dt>
+ *   <dd>OS: Darwin 19.4.0 Darwin Kernel Version 19.4.0: Wed Mar  4 22:28:40 PST 2020; root:xnu-6153.101.6~15/RELEASE_X86_64
+ *     <br>Java Runtime: Java(TM) SE Runtime Environment (1.8.0_241-b07)
+ *     <br>Java VM: Java HotSpot(TM) 64-Bit Server VM (25.241-b07)</dd>
+ * </dl>
+ *
+ * <table style="table-layout: fixed; border-collapse:collapse; border-spacing:0;">
+ * <colgroup>
+ *   <col style="width: 8%;">
+ *   <col style="width: 17%;">
+ *   <col style="width: 25%;">
+ *   <col style="width: 25%;">
+ *   <col style="width: 25%;">
+ * </colgroup>
+ * <thead>
+ *   <tr>
+ *     <th style="border-color:black;border-style:solid;border-width:1px;"></th>
+ *     <th style="border-color:black;border-style:solid;border-width:1px;"></th>
+ *     <th colspan="3" style="border-color:black;border-style:solid;border-width:1px; text-align: center;">Operating System</th>
+ *   </tr>
+ *   <tr>
+ *     <th style="border-color:black;border-style:solid;border-width:1px; text-align: center;">Source</th>
+ *     <th style="border-color:black;border-style:solid;border-width:1px; text-align: center;">Target</th>
+ *     <th style="border-color:black;border-style:solid;border-width:1px; text-align: center;">Windows</th>
+ *     <th style="border-color:black;border-style:solid;border-width:1px; text-align: center;">Mac OS X</th>
+ *     <th style="border-color:black;border-style:solid;border-width:1px; text-align: center;">Linux</th>
+ *   </tr>
+ * </thead>
+ * <tbody>
+ *   <tr>
+ *     <th colspan="5" style="border-color:black;border-style:solid;border-width:1px; text-align: center;">java.nio.file.Files.move(...)</th>
+ *   </tr>
+ *   <tr>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">File</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">File</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2714;</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2714;</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2714;</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">File</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">Directory</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2716;<br>AccessDeniedException</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2716;<br>FileSystemException<br>("Is a directory")</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2716;<br>FileSystemException<br>("Is a directory")</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">File</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">File Symlink</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2714;</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2714;</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2714;</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">File</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">Directory Symlink</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2716;<br>AccessDeniedException<br></td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2714;</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2714;</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">Directory</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">File</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2714;</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2716;<br>FileSystemException<br>("Not a directory")</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2716;<br>FileSystemException<br>("Not a directory")</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">Directory</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">Directory</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2716;<br>AccessDeniedException</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2714;</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2714;</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">Directory</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">File Symlink</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2714;</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2716;<br>FileSystemException<br>("Not a directory")</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2716;<br>FileSystemException<br>("Not a directory")</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">Directory</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">Directory Symlink</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2716;<br>AccessDeniedException</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2716;<br>FileSystemException<br>("Not a directory")</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2716;<br>FileSystemException<br>("Not a directory")</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">File Symlink</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">File</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2714;</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2714;</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2714;</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">File Symlink</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">Directory</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2716;<br>AccessDeniedException</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2716;<br>FileSystemException<br>("Is a directory")</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2716;<br>FileSystemException<br>("Is a directory")</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">File Symlink</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">File Symlink</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2714;</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2714;</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2714;</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">File Symlink</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">Directory Symlink</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2716;<br>AccessDeniedException<br></td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2714;</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2714;</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">Directory Symlink</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">File</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2714;</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2714;</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2714;</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">Directory Symlink</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">Directory</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2716;<br>AccessDeniedException</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2716;<br>FileSystemException<br>("Is a directory")</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2716;<br>FileSystemException<br>("Is a directory")</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">Directory Symlink</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">File Symlink</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2714;</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2714;</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2714;</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">Directory Symlink</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">Directory Symlink</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2716;<br>AccessDeniedException</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2714;</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">&#x2714;</td>
+ *   </tr>
+ *   <tr>
+ *     <th colspan="5" style="border-color:black;border-style:solid;border-width:1px; text-align: center;">java.nio.file.Files.createFile(...)</th>
+ *   </tr>
+ *   <tr>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">File</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">File</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">File</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">Directory</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">AccessDeniedException</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">File</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">File Symlink</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">File</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">Directory Symlink</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">AccessDeniedException</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *   </tr>
+ *   <tr>
+ *     <th colspan="5" style="border-color:black;border-style:solid;border-width:1px; text-align: center;">java.nio.file.Files.createDirectory(...)</th>
+ *   </tr>
+ *   <tr>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">Directory</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">File</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">Directory</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">Directory</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">Directory</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">File Symlink</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">Directory</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">Directory Symlink</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *   </tr>
+ *   <tr>
+ *     <th colspan="5" style="border-color:black;border-style:solid;border-width:1px; text-align: center;">java.nio.file.Files.createSymlink(...)</th>
+ *   </tr>
+ *   <tr>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">File Symlink</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">File</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">File Symlink</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">Directory</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">AccessDeniedException</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">File Symlink</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">File Symlink</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">File Symlink</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">Directory Symlink</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">AccessDeniedException</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">Directory Symlink</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">File</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">Directory Symlink</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">Directory</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">Directory Symlink</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">File Symlink</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">Directory Symlink</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px;">Directory Symlink</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *     <td style="border-color:black;border-style:solid;border-width:1px; text-align: center;">FileAlreadyExistsException</td>
+ *   </tr>
+ * </tbody>
+ * </table>
+ */
+public class FilesEnvironmentTest extends FilesTestBase {
+
+  private Path target;
+
+  @BeforeClass
+  public static void collectSystemInfo() {
+    assumeTrue("To enable, use -Dfiles.environment.test.enable=true",
+        Boolean.getBoolean("files.environment.test.enable"));
+
+    String systemDescription;
+    if (isWindows) {
+      systemDescription = identifyWindowsSystem();
+    } else {
+      systemDescription = identifyUnixSystem();
+    }
+    System.out.format("%n********************************************************************************%n"
+            + "    OS: %s%n"
+            + "    Java Runtime: %s (%s)%n"
+            + "    Java VM: %s (%s)%n"
+            + "********************************************************************************%n",
+        systemDescription,
+        System.getProperty("java.runtime.name", "unknown"), System.getProperty("java.runtime.version", "unknown"),
+        System.getProperty("java.vm.name", "unknown"), System.getProperty("java.vm.version", "unknown"));
+  }
+
+
+  @Before
+  public void prepareTarget() throws IOException {
+    target = createDirectory(root.resolve("target_" + testName.getMethodName()));  // root/target
+  }
+
+  @Test
+  public void testTryFileAtomicMoveToFile() throws Exception {
+    tryAtomicMove(PathType.FILE, this.topFile);
+  }
+
+  @Test
+  public void testTryFileAtomicMoveToDirectory() throws Exception {
+    tryAtomicMove(PathType.DIRECTORY, this.topFile);
+  }
+
+  @Test
+  public void testTryFileAtomicMoveToFileSymlink() throws Exception {
+    tryAtomicMove(PathType.SYMBOLIC_LINK_FILE, this.topFile);
+  }
+
+  @Test
+  public void testTryFileAtomicMoveToDirectorySymlink() throws Exception {
+    tryAtomicMove(PathType.SYMBOLIC_LINK_DIRECTORY, this.topFile);
+  }
+
+  @Test
+  public void testTryDirectoryAtomicMoveToFile() throws Exception {
+    tryAtomicMove(PathType.FILE, this.top);
+  }
+
+  @Test
+  public void testTryDirectoryAtomicMoveToDirectory() throws Exception {
+    tryAtomicMove(PathType.DIRECTORY, this.top);
+  }
+
+  @Test
+  public void testTryDirectoryAtomicMoveToFileSymlink() throws Exception {
+    tryAtomicMove(PathType.SYMBOLIC_LINK_FILE, this.top);
+  }
+
+  @Test
+  public void testTryDirectoryAtomicMoveToDirectorySymlink() throws Exception {
+    tryAtomicMove(PathType.SYMBOLIC_LINK_DIRECTORY, this.top);
+  }
+
+  @Test
+  public void testTryFileSymlinkAtomicMoveToFile() throws Exception {
+    assumeTrue("Skipped because symbolic links cannot be created in current environment", symlinksSupported);
+    tryAtomicMove(PathType.FILE, this.fileLink);
+  }
+
+  @Test
+  public void testTryFileSymlinkAtomicMoveToDirectory() throws Exception {
+    assumeTrue("Skipped because symbolic links cannot be created in current environment", symlinksSupported);
+    tryAtomicMove(PathType.DIRECTORY, this.fileLink);
+  }
+
+  @Test
+  public void testTryFileSymlinkAtomicMoveToFileSymlink() throws Exception {
+    assumeTrue("Skipped because symbolic links cannot be created in current environment", symlinksSupported);
+    tryAtomicMove(PathType.SYMBOLIC_LINK_FILE, this.fileLink);
+  }
+
+  @Test
+  public void testTryFileSymlinkAtomicMoveToDirectorySymlink() throws Exception {
+    assumeTrue("Skipped because symbolic links cannot be created in current environment", symlinksSupported);
+    tryAtomicMove(PathType.SYMBOLIC_LINK_DIRECTORY, this.fileLink);
+  }
+
+  @Test
+  public void testTryDirectorySymlinkAtomicMoveToFile() throws Exception {
+    assumeTrue("Skipped because symbolic links cannot be created in current environment", symlinksSupported);
+    tryAtomicMove(PathType.FILE, this.dirLink);
+  }
+
+  @Test
+  public void testTryDirectorySymlinkAtomicMoveToDirectory() throws Exception {
+    assumeTrue("Skipped because symbolic links cannot be created in current environment", symlinksSupported);
+    tryAtomicMove(PathType.DIRECTORY, this.dirLink);
+  }
+
+  @Test
+  public void testTryDirectorySymlinkAtomicMoveToFileSymlink() throws Exception {
+    assumeTrue("Skipped because symbolic links cannot be created in current environment", symlinksSupported);
+    tryAtomicMove(PathType.SYMBOLIC_LINK_FILE, this.dirLink);
+  }
+
+  @Test
+  public void testTryDirectorySymlinkAtomicMoveToDirectorySymlink() throws Exception {
+    assumeTrue("Skipped because symbolic links cannot be created in current environment", symlinksSupported);
+    tryAtomicMove(PathType.SYMBOLIC_LINK_DIRECTORY, this.dirLink);
+  }
+
+  @Test
+  public void testTryFileCreateToFile() throws Exception {
+    tryCreateExisting(PathType.FILE, p -> Files.createFile(p), "createFile");
+  }
+
+  @Test
+  public void testTryFileCreateToDirectory() throws Exception {
+    tryCreateExisting(PathType.DIRECTORY, p -> Files.createFile(p), "createFile");
+  }
+
+  @Test
+  public void testTryFileCreateToFileSymlink() throws Exception {
+    tryCreateExisting(PathType.SYMBOLIC_LINK_FILE, p -> Files.createFile(p), "createFile");
+  }
+
+  @Test
+  public void testTryFileCreateToDirectorySymlink() throws Exception {
+    tryCreateExisting(PathType.SYMBOLIC_LINK_DIRECTORY, p -> Files.createFile(p), "createFile");
+  }
+
+  @Test
+  public void testTryDirectoryCreateToFile() throws Exception {
+    tryCreateExisting(PathType.FILE, p -> Files.createDirectory(p), "createDirectory");
+  }
+
+  @Test
+  public void testTryDirectoryCreateToDirectory() throws Exception {
+    tryCreateExisting(PathType.DIRECTORY, p -> Files.createDirectory(p), "createDirectory");
+  }
+
+  @Test
+  public void testTryDirectoryCreateToFileSymlink() throws Exception {
+    tryCreateExisting(PathType.SYMBOLIC_LINK_FILE, p -> Files.createDirectory(p), "createDirectory");
+  }
+
+  @Test
+  public void testTryDirectoryCreateToDirectorySymlink() throws Exception {
+    tryCreateExisting(PathType.SYMBOLIC_LINK_DIRECTORY, p -> Files.createDirectory(p), "createDirectory");
+  }
+
+  @Test
+  public void testTryFileSymlinkCreateToFile() throws Exception {
+    tryCreateExisting(PathType.FILE, FilesEnvironmentTest::createFileSymlink, "createFileSymlink");
+  }
+
+  @Test
+  public void testTryFileSymlinkCreateToDirectory() throws Exception {
+    tryCreateExisting(PathType.DIRECTORY, FilesEnvironmentTest::createFileSymlink, "createFileSymlink");
+  }
+
+  @Test
+  public void testTryFileSymlinkCreateToFileSymlink() throws Exception {
+    tryCreateExisting(PathType.SYMBOLIC_LINK_FILE, FilesEnvironmentTest::createFileSymlink, "createFileSymlink");
+  }
+
+  @Test
+  public void testTryFileSymlinkCreateToDirectorySymlink() throws Exception {
+    tryCreateExisting(PathType.SYMBOLIC_LINK_DIRECTORY, FilesEnvironmentTest::createFileSymlink, "createFileSymlink");
+  }
+
+  @Test
+  public void testTryDirectorySymlinkCreateToFile() throws Exception {
+    tryCreateExisting(PathType.FILE, FilesEnvironmentTest::createDirectorySymlink, "createDirectorySymlink");
+  }
+
+  @Test
+  public void testTryDirectorySymlinkCreateToDirectory() throws Exception {
+    tryCreateExisting(PathType.DIRECTORY, FilesEnvironmentTest::createDirectorySymlink, "createDirectorySymlink");
+  }
+
+  @Test
+  public void testTryDirectorySymlinkCreateToFileSymlink() throws Exception {
+    tryCreateExisting(PathType.SYMBOLIC_LINK_FILE, FilesEnvironmentTest::createDirectorySymlink, "createDirectorySymlink");
+  }
+
+  @Test
+  public void testTryDirectorySymlinkCreateToDirectorySymlink() throws Exception {
+    tryCreateExisting(PathType.SYMBOLIC_LINK_DIRECTORY, FilesEnvironmentTest::createDirectorySymlink, "createDirectorySymlink");
+  }
+
+  private void tryAtomicMove(PathType type, Path source) throws IOException {
+    Path targetPath = type.create(target);
+    System.out.format("%n[%s/%s] Trying move(%s, %s, ATOMIC_MOVE)%n",
+        testName.getMethodName(), type, source, targetPath);
+    java.nio.file.Files.move(source, targetPath, StandardCopyOption.ATOMIC_MOVE);
+    System.out.format("[%s/%s] Successful%n", testName.getMethodName(), type);
+  }
+
+  private static Path createFileSymlink(Path path) throws IOException {
+    Path tempFile = java.nio.file.Files.createTempFile("delete_me", null);
+    tempFile.toFile().deleteOnExit();
+    try {
+      return Files.createSymbolicLink(path, tempFile);
+    } catch (IOException e) {
+      try {
+        org.terracotta.utilities.io.Files.deleteTree(tempFile);
+      } catch (Exception ex) {
+        e.addSuppressed(ex);
+      }
+      throw e;
+    }
+  }
+
+  private static Path createDirectorySymlink(Path path) throws IOException {
+    Path tempDir = java.nio.file.Files.createTempDirectory("delete_me");
+    tempDir.toFile().deleteOnExit();
+    try {
+      return Files.createSymbolicLink(path, tempDir);
+    } catch (IOException e) {
+      try {
+        org.terracotta.utilities.io.Files.deleteTree(tempDir);
+      } catch (Exception ex) {
+        e.addSuppressed(ex);
+      }
+      throw e;
+    }
+  }
+
+  private void tryCreateExisting(PathType type, ThrowingBiFunction<Path> function, String methodName)
+      throws IOException {
+    Path targetPath = type.create(target);
+    System.out.format("%n[%s/%s] Trying %s(%s)", testName.getMethodName(), type, methodName, targetPath);
+    try {
+      function.apply(targetPath);
+      fail("Expecting FileAlreadyExistsException");
+    } catch (FileAlreadyExistsException ignored) {
+      // expected
+    }
+    System.out.format("[%s/%s] Successful%n", testName.getMethodName(), type);
+  }
+
+  @FunctionalInterface
+  private interface ThrowingBiFunction<T> {
+    T apply(T t) throws IOException;
+  }
+
+  /**
+   * Invokes {@code systeminfo.exe} to collect Windows version details.
+   * @return a description of the Windows version
+   */
+  private static String identifyWindowsSystem() {
+    String systemInfo;
+    try {
+      Shell.Result result = Shell.execute(Shell.Encoding.CHARSET, "systeminfo.exe", "/FO", "LIST");
+      if (result.exitCode() == 0) {
+        String osName = "unknown";
+        String osVersion = "unknown";
+        Pattern lineParse = Pattern.compile("^([^\\s:][^:]+):\\s+(.+)$");
+        for (String line : result) {
+          Matcher matcher = lineParse.matcher(line);
+          if (matcher.matches()) {
+            String fieldName = matcher.group(1);
+            if (fieldName.equalsIgnoreCase("OS Name")) {
+              osName = matcher.group(2);
+            } else if (fieldName.equalsIgnoreCase("OS Version")) {
+              osVersion = matcher.group(2);
+            }
+          }
+        }
+        systemInfo = osName + " " + osVersion;
+      } else {
+        systemInfo = "unknown";
+      }
+    } catch (IOException e) {
+      systemInfo = "unknown";
+    }
+    return systemInfo;
+  }
+
+  /**
+   * Invokes {@code uname} to identify the *NIX system version details.
+   * @return a description of the *NIX version
+   */
+  private static String identifyUnixSystem() {
+    String systemInfo;
+    try {
+      Shell.Result result = Shell.execute(Shell.Encoding.CHARSET, "uname", "-srv");
+      if (result.exitCode() == 0) {
+        systemInfo = result.lines().get(0);
+      } else {
+        systemInfo = "unknown";
+      }
+    } catch (IndexOutOfBoundsException | IOException e) {
+      systemInfo = "unknown";
+    }
+    return systemInfo;
+  }
+
+  private enum PathType {
+    FILE("targetFile") {
+      @Override
+      Path createTarget(Path target) throws IOException {
+        Path path = createFile(target);
+        java.nio.file.Files.write(path, singleton(target.toString()), StandardCharsets.UTF_8);
+        return path;
+      }
+    },
+    DIRECTORY("targetDir") {
+      @Override
+      Path createTarget(Path target) throws IOException {
+        return createDirectory(target);
+      }
+    },
+    SYMBOLIC_LINK_FILE("targetFileLink") {
+      @Override
+      Path createTarget(Path target) throws IOException {
+        assumeTrue("Skipped because symbolic links cannot be created in current environment", symlinksSupported);
+        Path tempFile = java.nio.file.Files.createTempFile("delete_me", null);
+        tempFile.toFile().deleteOnExit();
+        return java.nio.file.Files.createSymbolicLink(target, tempFile);
+      }
+    },
+    SYMBOLIC_LINK_DIRECTORY("targetDirLink") {
+      @Override
+      Path createTarget(Path target) throws IOException {
+        assumeTrue("Skipped because symbolic links cannot be created in current environment", symlinksSupported);
+        Path tempDir = java.nio.file.Files.createTempDirectory("delete_me");
+        tempDir.toFile().deleteOnExit();
+        return java.nio.file.Files.createSymbolicLink(target, tempDir);
+      }
+    };
+
+    private final Path target;
+
+    PathType(String relativeTarget) {
+      this.target = Paths.get(relativeTarget);
+    }
+
+    abstract Path createTarget(Path target) throws IOException;
+
+    public Path create(Path targetDir) throws IOException {
+      assert java.nio.file.Files.isDirectory(targetDir);
+      Path target = targetDir.resolve(this.target);
+      target = createTarget(target);
+      System.out.format("%n[?/%s] Created: %s (%s)%n",
+          name(), target, java.nio.file.Files.exists(target, LinkOption.NOFOLLOW_LINKS));
+      return target;
+    }
+  }
+}

--- a/tools/src/test/java/org/terracotta/utilities/io/FilesRelocateDirectorySymlinkTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/io/FilesRelocateDirectorySymlinkTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2020 Terracotta, Inc., a Software AG company.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.utilities.io;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.nio.file.AccessDeniedException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.FileSystemException;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+import static java.nio.file.Files.exists;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
+
+/**
+ * Tests the {@link Files} {@code relocate} method with a <i>file symbolic link</i> source.
+ *
+ * @see FilesEnvironmentTest
+ */
+public class FilesRelocateDirectorySymlinkTest extends FilesRelocateTestBase {
+
+  @BeforeClass
+  public static void checkSymlinkSupport() {
+    assumeTrue("Skipped because symbolic links cannot be created in current environment", symlinksSupported);
+  }
+
+  @Test
+  public void testFileToExistingFileWithoutReplace() throws Exception {
+    Path targetPath = target.resolve(dirLink.getFileName());
+    makeFile(targetPath, singletonList("targetFile"));
+
+    try {
+      Files.relocate(dirLink, targetPath);
+      fail("Expecting FileAlreadyExistsException");
+    } catch (FileAlreadyExistsException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testFileToExistingDirectoryWithoutReplace() throws Exception {
+    Path targetPath = target.resolve(dirLink.getFileName());
+    makeDirectory(targetPath);
+
+    try {
+      Files.relocate(dirLink, targetPath);
+      fail("Expecting FileAlreadyExistsException");
+    } catch (FileAlreadyExistsException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testFileToExistingFileSymlinkWithoutReplace() throws Exception {
+    Path targetPath = target.resolve(dirLink.getFileName());
+    makeFileSymlink(targetPath, singletonList("linkTarget"));
+
+    try {
+      Files.relocate(dirLink, targetPath);
+      fail("Expecting FileAlreadyExistsException");
+    } catch (FileAlreadyExistsException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testFileToExistingDirectorySymlinkWithoutReplace() throws Exception {
+    Path targetPath = target.resolve(dirLink.getFileName());
+    makeDirectorySymlink(targetPath);
+
+    try {
+      Files.relocate(dirLink, targetPath);
+      fail("Expecting FileAlreadyExistsException");
+    } catch (FileAlreadyExistsException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testFileToExistingFileWithReplace() throws Exception {
+    Path targetPath = target.resolve(dirLink.getFileName());
+    makeFile(targetPath, singletonList("targetFile"));
+
+    Files.relocate(dirLink, targetPath, StandardCopyOption.REPLACE_EXISTING);
+    assertFalse(exists(dirLink, LinkOption.NOFOLLOW_LINKS));
+    assertTrue(exists(targetPath, LinkOption.NOFOLLOW_LINKS));
+  }
+
+  // On Windows, this test retries the relocate/rename until retries are exhausted
+  @Test
+  public void testFileToExistingDirectoryWithReplace() throws Exception {
+    Path targetPath = target.resolve(dirLink.getFileName());
+    makeDirectory(targetPath);
+
+    try {
+      Files.relocate(dirLink, targetPath, StandardCopyOption.REPLACE_EXISTING);
+      fail("Expecting " + (isWindows ? "AccessDeniedException" : "FileSystemException"));
+    } catch (AccessDeniedException e) {
+      // When moving a file onto an existing directory, Windows throws AccessDeniedException
+      if (!isWindows) {
+        throw e;
+      }
+    } catch (FileSystemException e) {
+      // When moving a file onto an existing directory, Unix throws FileSystemException
+      if (isWindows) {
+        throw e;
+      } else {
+        assertThat(e.getReason(), is("Is a directory"));
+      }
+    }
+    // So much for write once, run anywhere ...
+  }
+
+  @Test
+  public void testFileToExistingFileSymlinkWithReplace() throws Exception {
+    Path targetPath = target.resolve(dirLink.getFileName());
+    makeFileSymlink(targetPath, singletonList("targetFile"));
+
+    Files.relocate(dirLink, targetPath, StandardCopyOption.REPLACE_EXISTING);
+    assertFalse(exists(dirLink, LinkOption.NOFOLLOW_LINKS));
+    assertTrue(exists(targetPath, LinkOption.NOFOLLOW_LINKS));
+  }
+
+  // On Windows, this test retries the relocate/rename until retries are exhausted
+  @Test
+  public void testFileToExistingDirectorySymlinkWithReplace() throws Exception {
+    Path targetPath = target.resolve(dirLink.getFileName());
+    makeDirectorySymlink(targetPath);
+
+    try {
+      Files.relocate(dirLink, targetPath, StandardCopyOption.REPLACE_EXISTING);
+      if (isWindows) {
+        fail("Expecting AccessDeniedException");
+      }
+      assertFalse(exists(dirLink, LinkOption.NOFOLLOW_LINKS));
+      assertTrue(exists(targetPath, LinkOption.NOFOLLOW_LINKS));
+    } catch (AccessDeniedException e) {
+      // When moving a file onto an existing directory symlink, Windows throws AccessDeniedException
+      if (!isWindows) {
+        throw e;
+      }
+    }
+    // So much for write once, run anywhere ...
+  }
+}

--- a/tools/src/test/java/org/terracotta/utilities/io/FilesRelocateDirectoryTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/io/FilesRelocateDirectoryTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2020 Terracotta, Inc., a Software AG company.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.utilities.io;
+
+import org.junit.Test;
+
+import java.nio.file.AccessDeniedException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.FileSystemException;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+import static java.nio.file.Files.exists;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests the {@link Files} {@code relocate} method with a <i>directory</i> source.
+ *
+ * @see FilesEnvironmentTest
+ */
+public class FilesRelocateDirectoryTest extends FilesRelocateTestBase {
+
+  @Test
+  public void testDirectoryToExistingFileWithoutReplace() throws Exception {
+    Path targetPath = target.resolve(top.getFileName());
+    makeFile(targetPath, singletonList("targetFile"));
+
+    try {
+      Files.relocate(top, targetPath);
+      fail("Expecting FileAlreadyExistsException");
+    } catch (FileAlreadyExistsException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testDirectoryToExistingDirectoryWithoutReplace() throws Exception {
+    Path targetPath = target.resolve(top.getFileName());
+    makeDirectory(targetPath);
+
+    try {
+      Files.relocate(top, targetPath);
+      fail("Expecting FileAlreadyExistsException");
+    } catch (FileAlreadyExistsException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testDirectoryToExistingFileSymlinkWithoutReplace() throws Exception {
+    Path targetPath = target.resolve(top.getFileName());
+    makeFileSymlink(targetPath, singletonList("linkTarget"));
+
+    try {
+      Files.relocate(top, targetPath);
+      fail("Expecting FileAlreadyExistsException");
+    } catch (FileAlreadyExistsException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testDirectoryToExistingDirectorySymlinkWithoutReplace() throws Exception {
+    Path targetPath = target.resolve(top.getFileName());
+    makeDirectorySymlink(targetPath);
+
+    try {
+      Files.relocate(top, targetPath);
+      fail("Expecting FileAlreadyExistsException");
+    } catch (FileAlreadyExistsException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testDirectoryToExistingFileWithReplace() throws Exception {
+    Path targetPath = target.resolve(top.getFileName());
+    makeFile(targetPath, singletonList("targetFile"));
+
+    PathDetails sourceDetail = new PathDetails(top.getParent(), top, false);
+
+    try {
+      Files.relocate(top, targetPath, StandardCopyOption.REPLACE_EXISTING);
+      if (!isWindows) {
+        fail("Expecting FileSystemException");
+      }
+      assertFalse(exists(top, LinkOption.NOFOLLOW_LINKS));
+      assertTrue(exists(targetPath, LinkOption.NOFOLLOW_LINKS));
+
+      PathDetails targetDetail = new PathDetails(targetPath.getParent(), targetPath, false);
+      assertTrue("Target " + targetDetail + " does not mirror\n    source " + sourceDetail, targetDetail.mirrors(sourceDetail, false));
+
+    } catch (FileSystemException e) {
+      if (isWindows) {
+        throw e;
+      } else {
+        assertThat(e.getReason(), is("Not a directory"));
+      }
+    }
+  }
+
+  // On Windows, this test retries the relocate/rename until retries are exhausted
+  @Test
+  public void testDirectoryToExistingDirectoryWithReplace() throws Exception {
+    Path targetPath = target.resolve(top.getFileName());
+    makeDirectory(targetPath);
+
+    PathDetails sourceDetail = new PathDetails(top.getParent(), top, false);
+
+    try {
+      Files.relocate(top, targetPath, StandardCopyOption.REPLACE_EXISTING);
+      if (isWindows) {
+        fail("Expecting AccessDeniedException");
+      }
+      assertFalse(exists(top, LinkOption.NOFOLLOW_LINKS));
+      assertTrue(exists(targetPath, LinkOption.NOFOLLOW_LINKS));
+
+      PathDetails targetDetail = new PathDetails(targetPath.getParent(), targetPath, false);
+      assertTrue("Target " + targetDetail + " does not mirror\n    source " + sourceDetail, targetDetail.mirrors(sourceDetail, false));
+
+    } catch (AccessDeniedException e) {
+      if (!isWindows) {
+        throw e;
+      }
+    }
+  }
+
+  @Test
+  public void testDirectoryToExistingFileSymlinkWithReplace() throws Exception {
+    Path targetPath = target.resolve(top.getFileName());
+    makeFileSymlink(targetPath, singletonList("targetFile"));
+
+    PathDetails sourceDetail = new PathDetails(top.getParent(), top, false);
+
+    try {
+      Files.relocate(top, targetPath, StandardCopyOption.REPLACE_EXISTING);
+      if (!isWindows) {
+        fail("Expecting FileSystemException");
+      }
+      assertFalse(exists(top, LinkOption.NOFOLLOW_LINKS));
+      assertTrue(exists(targetPath, LinkOption.NOFOLLOW_LINKS));
+
+      PathDetails targetDetail = new PathDetails(targetPath.getParent(), targetPath, false);
+      assertTrue("Target " + targetDetail + " does not mirror\n    source " + sourceDetail, targetDetail.mirrors(sourceDetail, false));
+
+    } catch (FileSystemException e) {
+      if (isWindows) {
+        throw e;
+      } else {
+        assertThat(e.getReason(), is("Not a directory"));
+      }
+    }
+  }
+
+  @Test
+  public void testDirectoryToExistingDirectorySymlinkWithReplace() throws Exception {
+    Path targetPath = target.resolve(top.getFileName());
+    makeDirectorySymlink(targetPath);
+
+    try {
+      Files.relocate(top, targetPath, StandardCopyOption.REPLACE_EXISTING);
+      fail("Expecting " + (isWindows ? "AccessDeniedException" : "FileSystemException"));
+    } catch (AccessDeniedException e) {
+      // When moving a file onto an existing directory symlink, Windows throws AccessDeniedException
+      if (!isWindows) {
+        throw e;
+      }
+    } catch (FileSystemException e) {
+      // When moving a file onto an existing directory symlink, Unix throws FileSystemException
+      if (isWindows) {
+        throw e;
+      } else {
+        assertThat(e.getReason(), is("Not a directory"));
+      }
+    }
+  }
+}

--- a/tools/src/test/java/org/terracotta/utilities/io/FilesRelocateFileSymlinkTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/io/FilesRelocateFileSymlinkTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2020 Terracotta, Inc., a Software AG company.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.utilities.io;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.FileSystemException;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+import static java.nio.file.Files.exists;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
+
+/**
+ * Tests the {@link Files} {@code relocate} method with a <i>file symbolic link</i> source.
+ *
+ * @see FilesEnvironmentTest
+ */
+public class FilesRelocateFileSymlinkTest extends FilesRelocateTestBase {
+
+  @BeforeClass
+  public static void checkSymlinkSupport() {
+    assumeTrue("Skipped because symbolic links cannot be created in current environment", symlinksSupported);
+  }
+
+  @Test
+  public void testFileToExistingFileWithoutReplace() throws Exception {
+    Path targetPath = target.resolve(fileLink.getFileName());
+    makeFile(targetPath, singletonList("targetFile"));
+
+    try {
+      Files.relocate(fileLink, targetPath);
+      fail("Expecting FileAlreadyExistsException");
+    } catch (FileAlreadyExistsException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testFileToExistingDirectoryWithoutReplace() throws Exception {
+    Path targetPath = target.resolve(fileLink.getFileName());
+    makeDirectory(targetPath);
+
+    try {
+      Files.relocate(fileLink, targetPath);
+      fail("Expecting FileAlreadyExistsException");
+    } catch (FileAlreadyExistsException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testFileToExistingFileSymlinkWithoutReplace() throws Exception {
+    Path targetPath = target.resolve(fileLink.getFileName());
+    makeFileSymlink(targetPath, singletonList("linkTarget"));
+
+    try {
+      Files.relocate(fileLink, targetPath);
+      fail("Expecting FileAlreadyExistsException");
+    } catch (FileAlreadyExistsException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testFileToExistingDirectorySymlinkWithoutReplace() throws Exception {
+    Path targetPath = target.resolve(fileLink.getFileName());
+    makeDirectorySymlink(targetPath);
+
+    try {
+      Files.relocate(fileLink, targetPath);
+      fail("Expecting FileAlreadyExistsException");
+    } catch (FileAlreadyExistsException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testFileToExistingFileWithReplace() throws Exception {
+    Path targetPath = target.resolve(fileLink.getFileName());
+    makeFile(targetPath, singletonList("targetFile"));
+
+    Files.relocate(fileLink, targetPath, StandardCopyOption.REPLACE_EXISTING);
+    assertFalse(exists(fileLink, LinkOption.NOFOLLOW_LINKS));
+    assertTrue(exists(targetPath, LinkOption.NOFOLLOW_LINKS));
+    assertThat(java.nio.file.Files.readAllLines(targetPath, StandardCharsets.UTF_8), is(singletonList("commonFile")));
+  }
+
+  // On Windows, this test retries the relocate/rename until retries are exhausted
+  @Test
+  public void testFileToExistingDirectoryWithReplace() throws Exception {
+    Path targetPath = target.resolve(fileLink.getFileName());
+    makeDirectory(targetPath);
+
+    try {
+      Files.relocate(fileLink, targetPath, StandardCopyOption.REPLACE_EXISTING);
+      fail("Expecting " + (isWindows ? "AccessDeniedException" : "FileSystemException"));
+    } catch (AccessDeniedException e) {
+      // When moving a file onto an existing directory, Windows throws AccessDeniedException
+      if (!isWindows) {
+        throw e;
+      }
+    } catch (FileSystemException e) {
+      // When moving a file onto an existing directory, Unix throws FileSystemException
+      if (isWindows) {
+        throw e;
+      } else {
+        assertThat(e.getReason(), is("Is a directory"));
+      }
+    }
+    // So much for write once, run anywhere ...
+  }
+
+  @Test
+  public void testFileToExistingFileSymlinkWithReplace() throws Exception {
+    Path targetPath = target.resolve(fileLink.getFileName());
+    makeFileSymlink(targetPath, singletonList("targetFile"));
+
+    Files.relocate(fileLink, targetPath, StandardCopyOption.REPLACE_EXISTING);
+    assertFalse(exists(fileLink, LinkOption.NOFOLLOW_LINKS));
+    assertTrue(exists(targetPath, LinkOption.NOFOLLOW_LINKS));
+    assertThat(java.nio.file.Files.readAllLines(targetPath, StandardCharsets.UTF_8), is(singletonList("commonFile")));
+  }
+
+  // On Windows, this test retries the relocate/rename until retries are exhausted
+  @Test
+  public void testFileToExistingDirectorySymlinkWithReplace() throws Exception {
+    Path targetPath = target.resolve(fileLink.getFileName());
+    makeDirectorySymlink(targetPath);
+
+    try {
+      Files.relocate(fileLink, targetPath, StandardCopyOption.REPLACE_EXISTING);
+      if (isWindows) {
+        fail("Expecting AccessDeniedException");
+      }
+      assertFalse(exists(fileLink, LinkOption.NOFOLLOW_LINKS));
+      assertTrue(exists(targetPath, LinkOption.NOFOLLOW_LINKS));
+      assertThat(java.nio.file.Files.readAllLines(targetPath, StandardCharsets.UTF_8), is(singletonList("commonFile")));
+    } catch (AccessDeniedException e) {
+      // When moving a file onto an existing directory symlink, Windows throws AccessDeniedException
+      if (!isWindows) {
+        throw e;
+      }
+    }
+    // So much for write once, run anywhere ...
+  }
+}

--- a/tools/src/test/java/org/terracotta/utilities/io/FilesRelocateFileTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/io/FilesRelocateFileTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2020 Terracotta, Inc., a Software AG company.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.utilities.io;
+
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.FileSystemException;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+import static java.nio.file.Files.exists;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests the {@link Files} {@code relocate} method with a <i>file</i> source.
+ *
+ * @see FilesEnvironmentTest
+ */
+public class FilesRelocateFileTest extends FilesRelocateTestBase {
+
+  @Test
+  public void testFileToExistingFileWithoutReplace() throws Exception {
+    Path targetPath = target.resolve(topFile.getFileName());
+    makeFile(targetPath, singletonList("targetFile"));
+
+    try {
+      Files.relocate(topFile, targetPath);
+      fail("Expecting FileAlreadyExistsException");
+    } catch (FileAlreadyExistsException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testFileToExistingDirectoryWithoutReplace() throws Exception {
+    Path targetPath = target.resolve(topFile.getFileName());
+    makeDirectory(targetPath);
+
+    try {
+      Files.relocate(topFile, targetPath);
+      fail("Expecting FileAlreadyExistsException");
+    } catch (FileAlreadyExistsException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testFileToExistingFileSymlinkWithoutReplace() throws Exception {
+    Path targetPath = target.resolve(topFile.getFileName());
+    makeFileSymlink(targetPath, singletonList("linkTarget"));
+
+    try {
+      Files.relocate(topFile, targetPath);
+      fail("Expecting FileAlreadyExistsException");
+    } catch (FileAlreadyExistsException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testFileToExistingDirectorySymlinkWithoutReplace() throws Exception {
+    Path targetPath = target.resolve(topFile.getFileName());
+    makeDirectorySymlink(targetPath);
+
+    try {
+      Files.relocate(topFile, targetPath);
+      fail("Expecting FileAlreadyExistsException");
+    } catch (FileAlreadyExistsException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testFileToExistingFileWithReplace() throws Exception {
+    Path targetPath = target.resolve(topFile.getFileName());
+    makeFile(targetPath, singletonList("targetFile"));
+
+    Files.relocate(topFile, targetPath, StandardCopyOption.REPLACE_EXISTING);
+    assertFalse(exists(topFile, LinkOption.NOFOLLOW_LINKS));
+    assertTrue(exists(targetPath, LinkOption.NOFOLLOW_LINKS));
+    assertThat(java.nio.file.Files.readAllLines(targetPath, StandardCharsets.UTF_8), is(singletonList("topFile")));
+  }
+
+  // On Windows, this test retries the relocate/rename until retries are exhausted
+  @Test
+  public void testFileToExistingDirectoryWithReplace() throws Exception {
+    Path targetPath = target.resolve(topFile.getFileName());
+    makeDirectory(targetPath);
+
+    try {
+      Files.relocate(topFile, targetPath, StandardCopyOption.REPLACE_EXISTING);
+      fail("Expecting " + (isWindows ? "AccessDeniedException" : "FileSystemException"));
+    } catch (AccessDeniedException e) {
+      // When moving a file onto an existing directory, Windows throws AccessDeniedException
+      if (!isWindows) {
+        throw e;
+      }
+    } catch (FileSystemException e) {
+      // When moving a file onto an existing directory, Unix throws FileSystemException
+      if (isWindows) {
+        throw e;
+      } else {
+        assertThat(e.getReason(), is("Is a directory"));
+      }
+    }
+    // So much for write once, run anywhere ...
+  }
+
+  @Test
+  public void testFileToExistingFileSymlinkWithReplace() throws Exception {
+    Path targetPath = target.resolve(topFile.getFileName());
+    makeFileSymlink(targetPath, singletonList("targetFile"));
+
+    Files.relocate(topFile, targetPath, StandardCopyOption.REPLACE_EXISTING);
+    assertFalse(exists(topFile, LinkOption.NOFOLLOW_LINKS));
+    assertTrue(exists(targetPath, LinkOption.NOFOLLOW_LINKS));
+    assertThat(java.nio.file.Files.readAllLines(targetPath, StandardCharsets.UTF_8), is(singletonList("topFile")));
+  }
+
+  // On Windows, this test retries the relocate/rename until retries are exhausted
+  @Test
+  public void testFileToExistingDirectorySymlinkWithReplace() throws Exception {
+    Path targetPath = target.resolve(topFile.getFileName());
+    makeDirectorySymlink(targetPath);
+
+    try {
+      Files.relocate(topFile, targetPath, StandardCopyOption.REPLACE_EXISTING);
+      if (isWindows) {
+        fail("Expecting AccessDeniedException");
+      }
+      assertFalse(exists(topFile, LinkOption.NOFOLLOW_LINKS));
+      assertTrue(exists(targetPath, LinkOption.NOFOLLOW_LINKS));
+      assertThat(java.nio.file.Files.readAllLines(targetPath, StandardCharsets.UTF_8), is(singletonList("topFile")));
+    } catch (AccessDeniedException e) {
+      // When moving a file onto an existing directory symlink, Windows throws AccessDeniedException
+      if (!isWindows) {
+        throw e;
+      }
+    }
+    // So much for write once, run anywhere ...
+  }
+}

--- a/tools/src/test/java/org/terracotta/utilities/io/FilesRelocateTestBase.java
+++ b/tools/src/test/java/org/terracotta/utilities/io/FilesRelocateTestBase.java
@@ -17,12 +17,10 @@ package org.terracotta.utilities.io;
 
 import org.junit.Before;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.CopyOption;
 import java.nio.file.Path;
 
 import static java.nio.file.Files.createDirectory;
-import static org.junit.Assume.assumeTrue;
 
 /**
  * Common core for {@link Files#relocate(Path, Path, CopyOption...)} testing.
@@ -34,26 +32,5 @@ public abstract class FilesRelocateTestBase extends FilesTestBase {
   @Before
   public void prepareTarget() throws IOException {
     target = createDirectory(root.resolve("target_" + testName.getMethodName()));  // root/target
-  }
-
-  protected static Path makeFile(Path path, Iterable<String> lines) throws IOException {
-    java.nio.file.Files.createFile(path);
-    return java.nio.file.Files.write(path, lines, StandardCharsets.UTF_8);
-  }
-
-  protected static Path makeDirectory(Path path) throws IOException {
-    return java.nio.file.Files.createDirectory(path);
-  }
-
-  protected static Path makeFileSymlink(Path filePath, Iterable<String> lines) throws IOException {
-    assumeTrue("Skipped because symbolic links cannot be created in current environment", symlinksSupported);
-    Path linkTarget = TEST_ROOT.newFile().toPath();
-    java.nio.file.Files.write(linkTarget, lines, StandardCharsets.UTF_8);
-    return java.nio.file.Files.createSymbolicLink(filePath, linkTarget);
-  }
-
-  protected static Path makeDirectorySymlink(Path dirPath) throws IOException {
-    assumeTrue("Skipped because symbolic links cannot be created in current environment", symlinksSupported);
-    return java.nio.file.Files.createSymbolicLink(dirPath, TEST_ROOT.newFolder().toPath());
   }
 }

--- a/tools/src/test/java/org/terracotta/utilities/io/FilesRelocateTestBase.java
+++ b/tools/src/test/java/org/terracotta/utilities/io/FilesRelocateTestBase.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Terracotta, Inc., a Software AG company.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.utilities.io;
+
+import org.junit.Before;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.CopyOption;
+import java.nio.file.Path;
+
+import static java.nio.file.Files.createDirectory;
+import static org.junit.Assume.assumeTrue;
+
+/**
+ * Common core for {@link Files#relocate(Path, Path, CopyOption...)} testing.
+ */
+public abstract class FilesRelocateTestBase extends FilesTestBase {
+
+  protected Path target;
+
+  @Before
+  public void prepareTarget() throws IOException {
+    target = createDirectory(root.resolve("target_" + testName.getMethodName()));  // root/target
+  }
+
+  protected static Path makeFile(Path path, Iterable<String> lines) throws IOException {
+    java.nio.file.Files.createFile(path);
+    return java.nio.file.Files.write(path, lines, StandardCharsets.UTF_8);
+  }
+
+  protected static Path makeDirectory(Path path) throws IOException {
+    return java.nio.file.Files.createDirectory(path);
+  }
+
+  protected static Path makeFileSymlink(Path filePath, Iterable<String> lines) throws IOException {
+    assumeTrue("Skipped because symbolic links cannot be created in current environment", symlinksSupported);
+    Path linkTarget = TEST_ROOT.newFile().toPath();
+    java.nio.file.Files.write(linkTarget, lines, StandardCharsets.UTF_8);
+    return java.nio.file.Files.createSymbolicLink(filePath, linkTarget);
+  }
+
+  protected static Path makeDirectorySymlink(Path dirPath) throws IOException {
+    assumeTrue("Skipped because symbolic links cannot be created in current environment", symlinksSupported);
+    return java.nio.file.Files.createSymbolicLink(dirPath, TEST_ROOT.newFolder().toPath());
+  }
+}

--- a/tools/src/test/java/org/terracotta/utilities/io/FilesRenameTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/io/FilesRenameTest.java
@@ -137,7 +137,7 @@ public class FilesRenameTest extends FilesTestBase {
     try (PathHolder holder = new PathHolder(topFile, Duration.ofMillis(100))) {
       holder.start();
       Thread.currentThread().interrupt();
-      renamedPath = Files.rename(topFile, newName, holder.getHoldTime());
+      renamedPath = Files.rename(topFile, newName, holder.getHoldTime().multipliedBy(2));
       assertTrue(Thread.interrupted());
     }
     assertFalse(exists(topFile, LinkOption.NOFOLLOW_LINKS));


### PR DESCRIPTION
This commit stream corrects the following:

* Files.relocate relative target handling
* Files.relocate existing target w/o REPLACE_EXISTING
* Files.rename return with relative target

It also adds more testing for Files.relocate and Files.rename and makes a couple of other minor corrections.

Not that this commit stream does not alter the exceptions thrown in the event of an incompatible existing target -- normalization was considered but I thought a discussion should be had first.