### PR TITLE
Add classes to help with logging and "live" diagnostic output.

### DIFF
--- a/tools/src/main/java/org/terracotta/utilities/io/CapturedPrintStream.java
+++ b/tools/src/main/java/org/terracotta/utilities/io/CapturedPrintStream.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 Terracotta, Inc., a Software AG company.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.utilities.io;
+
+import java.io.BufferedOutputStream;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Extends {@link PrintStream} to capture the output to an in-memory buffer.
+ * The captured stream is available by calling {@link #getReader()}.
+ * {@link StandardCharsets#UTF_8 UTF-8} is used for encoding and decoding the stream
+ * content.
+ *
+ * @see #getInstance()
+ */
+public final class CapturedPrintStream extends PrintStream {
+
+  private CapturedPrintStream() throws UnsupportedEncodingException {
+    super(new LocalBufferedOutputStream(4096), false, StandardCharsets.UTF_8.name());
+  }
+
+  /**
+   * Instantiates a new {@code CapturedPrintStream}.
+   * @return a new {@code CapturedPrintStream}
+   */
+  public static CapturedPrintStream getInstance() {
+    try {
+      return new CapturedPrintStream();
+    } catch (UnsupportedEncodingException e) {
+      throw new AssertionError("Unexpected exception creating CapturedPrintStream", e);
+    }
+  }
+
+  /**
+   * Gets a {@code BufferedReader} over the bytes written to this {@code PrintStream}.
+   * Bytes copied from the stream to the reader are converted to {@code UTF-8}.
+   * @return a new {@code BufferedReader} over the bytes written to this stream
+   */
+  public BufferedReader getReader() {
+    flush();
+    return new BufferedReader(new InputStreamReader(new ByteArrayInputStream(toByteArray()), StandardCharsets.UTF_8), 4096);
+  }
+
+  private byte[] toByteArray() {
+    return ((LocalBufferedOutputStream)out).toByteArray();
+  }
+
+  private static final class LocalBufferedOutputStream extends BufferedOutputStream {
+    LocalBufferedOutputStream(int size) {
+      super(new ByteArrayOutputStream(size), size);
+    }
+
+    byte[] toByteArray() {
+      return ((ByteArrayOutputStream)out).toByteArray();
+    }
+  }
+}

--- a/tools/src/main/java/org/terracotta/utilities/io/NullOutputStream.java
+++ b/tools/src/main/java/org/terracotta/utilities/io/NullOutputStream.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Terracotta, Inc., a Software AG company.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.utilities.io;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * An {@code OutputStream} which discards all data written to it.
+ * For Java 11 and beyond, use {@code OutputStream.nullOutputStream()}.
+ */
+public class NullOutputStream extends OutputStream {
+
+  private volatile boolean closed = false;
+
+  @Override
+  public void write(int b) throws IOException {
+    checkClosed();
+  }
+
+  @Override
+  public void write(byte[] b, int off, int len) throws IOException {
+    int arrayLength = b.length;
+    if ((arrayLength | off | len) < 0 || len > arrayLength - off) {
+      throw new IndexOutOfBoundsException();
+    }
+    checkClosed();
+  }
+
+  @Override
+  public void close() {
+    closed = true;
+  }
+
+  private void checkClosed() throws IOException {
+    if (closed) {
+      throw new IOException("Stream closed");
+    }
+  }
+}

--- a/tools/src/main/java/org/terracotta/utilities/io/buffer/DumpUtility.java
+++ b/tools/src/main/java/org/terracotta/utilities/io/buffer/DumpUtility.java
@@ -1,0 +1,508 @@
+/*
+ * Copyright 2020 Terracotta, Inc., a Software AG company.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.utilities.io.buffer;
+
+import java.io.PrintStream;
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+import java.nio.IntBuffer;
+import java.nio.LongBuffer;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Formatter;
+import java.util.IdentityHashMap;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Provides methods to dump {@link java.nio.Buffer} instances.
+ * <p>
+ * Each instance of this class tracks the buffers it dumps and does not dump the
+ * same buffer more than once.  Because of this, an instance of this class should
+ * not be retained beyond actual need to avoid interfering with garbage collection
+ * of the dumped buffers.
+ *
+ * <h3>Use of Reflection</h3>
+ * This class uses reflection to access fields internal to {@code Buffer} implementations.
+ * Operation of the following methods <i>requires</i> this access:
+ * <ul>
+ *   <li>{@link #dumpBuffer(IntBuffer)}</li>
+ *   <li>{@link #dumpBuffer(IntBuffer, PrintStream)}</li>
+ *   <li>{@link #dumpBuffer(LongBuffer)}</li>
+ *   <li>{@link #dumpBuffer(LongBuffer, PrintStream)}</li>
+ * </ul>
+ */
+@SuppressWarnings("UnusedDeclaration")
+public final class DumpUtility {
+  /**
+   * The {@code PrintStream} to which the dump is written.
+   */
+  private final PrintStream printStream;
+
+  /**
+   * The prefix to prepend to each emitted line.
+   */
+  private final CharSequence linePrefix;
+
+  /**
+   * Tracks objects already dumped.
+   */
+  private final Set<Object> dumpedSet = Collections.newSetFromMap(new IdentityHashMap<>());
+
+  /**
+   * Constructs a new {@code DumpUtility} using the {@code PrintStream} provided.
+   * This constructor is equivalent to
+   * {@link #DumpUtility(PrintStream, CharSequence) new DumpUtility(printStream, "")}.
+   *
+   * @param printStream the {@code PrintStream} to which the dump is written
+   */
+  public DumpUtility(PrintStream printStream) {
+    this(printStream, "");
+  }
+
+  /**
+   * Constructs a new {@code DumpUtility} using the {@code PrintStream} and line prefix provided.
+   * @param printStream the {@code PrintStream} to which the dump is written
+   * @param linePrefix the value to prepend to each dump line written
+   */
+  public DumpUtility(PrintStream printStream, CharSequence linePrefix) {
+    this.printStream = requireNonNull(printStream, "printStream");
+    this.linePrefix = requireNonNull(linePrefix, "linePrefix");
+  }
+
+  /**
+   * Tracks objects dumped by this {@code DumpUtility} instance to permit avoidance of
+   * duplicate dumps of data structures.  This method write a line to {@code printStream}:
+   * if the object not been dumped, the line is suitable to identify the object being
+   * dumped; if the object has been dumped, the line is a reference to the identity
+   * previously displayed.
+   *
+   * @param o the object to track
+   *
+   * @return {@code true} if {@code o} was previously dumped
+   */
+  private boolean wasDumped(Object o) {
+    if (this.dumpedSet.contains(o)) {
+      printStream.format("%s    ==> %s%n", linePrefix, getObjectId(o));
+      return true;
+    }
+    this.dumpedSet.add(o);
+    printStream.format("%s[%s]%n", linePrefix, getObjectId(o));
+    return false;
+  }
+
+  /**
+   * A convenience method that allocates a {@code DumpUtility} instance, dumps a buffer,
+   * and discards the {@code DumpUtility} instance.
+   * @param buffer the {@code IntBuffer} to dump
+   * @param printStream the {@code PrintStream} to which the dump is written
+   *
+   * @throws UnsupportedOperationException if the {@code buffer} is not a supported type or
+   *      reflective access to a required field fails
+   */
+  public static void dumpBuffer(IntBuffer buffer, PrintStream printStream) {
+    new DumpUtility(printStream).dumpBuffer(buffer);
+  }
+
+  /**
+   * A convenience method that allocates a {@code DumpUtility} instance, dumps a buffer,
+   * and discards the {@code DumpUtility} instance.
+   * @param buffer the {@code LongBuffer} to dump
+   * @param printStream the {@code PrintStream} to which the dump is written
+   *
+   * @throws UnsupportedOperationException if the {@code buffer} is not a supported type or
+   *      reflective access to a required field fails
+   */
+  public static void dumpBuffer(LongBuffer buffer, PrintStream printStream) {
+    new DumpUtility(printStream).dumpBuffer(buffer);
+  }
+
+  /**
+   * A convenience method that allocates a {@code DumpUtility} instance, dumps a buffer,
+   * and discards the {@code DumpUtility} instance.
+   * @param buffer the {@code ByteBuffer} to dump
+   * @param printStream the {@code PrintStream} to which the dump is written
+   */
+  public static void dumpBuffer(ByteBuffer buffer, PrintStream printStream) {
+    new DumpUtility(printStream).dumpBuffer(buffer);
+  }
+
+
+  /**
+   * Attempts to dump a {@link IntBuffer IntBuffer}.  The present implementation of this
+   * method depends the use of {@link ByteBuffer#asIntBuffer() ByteBuffer.asIntBuffer} in
+   * creation of {@code buffer} <b>and</b> on the internal implementation of {@code ByteBuffer}.
+   *
+   * @param buffer the {@code IntBuffer} instance to dump
+   *
+   * @throws UnsupportedOperationException if the {@code buffer} is not a supported type or
+   *      reflective access to a required field fails
+   */
+  public void dumpBuffer(IntBuffer buffer) {
+    requireNonNull(buffer, "buffer");
+
+    if (wasDumped(buffer)) {
+      return;
+    }
+
+    String bufferClassName = buffer.getClass().getName();
+    String byteBufferFieldName;
+    if (bufferClassName.equals("java.nio.ByteBufferAsInfBufferB")
+        || bufferClassName.equals("java.nio.ByteBufferAsIntBufferL")
+        || bufferClassName.equals("java.nio.ByteBufferAsIntBufferRB")
+        || bufferClassName.equals("java.nio.ByteBufferAsIntBufferRL")) {
+      byteBufferFieldName = "bb";
+
+    } else if (bufferClassName.equals("java.nio.DirectIntBufferU")
+        || bufferClassName.equals("java.nio.DirectIntBufferS")
+        || bufferClassName.equals("java.nio.DirectIntBufferRU")
+        || bufferClassName.equals("java.nio.DirectIntBufferRS")) {
+      byteBufferFieldName = "att";
+
+    } else {
+      throw new UnsupportedOperationException(String.format("LongBuffer type not supported: %s", bufferClassName));
+    }
+
+    dumpBuffer(getFieldValue(ByteBuffer.class, buffer, byteBufferFieldName));
+  }
+
+  /**
+   * Attempts to dump a {@link LongBuffer LongBuffer}.  The present implementation of this
+   * method depends the use of {@link ByteBuffer#asLongBuffer() ByteBuffer.asLongBuffer} in
+   * creation of {@code buffer} <b>and</b> on the internal implementation of {@code ByteBuffer}.
+   *
+   * @param buffer the {@code LongBuffer} instance to dump
+   *
+   * @throws UnsupportedOperationException if the {@code buffer} is not a supported type or
+   *      reflective access to a required field fails
+   */
+  public void dumpBuffer(LongBuffer buffer) {
+    requireNonNull(buffer, "buffer");
+
+    if (wasDumped(buffer)) {
+      return;
+    }
+
+    String bufferClassName = buffer.getClass().getName();
+    String byteBufferFieldName;
+    if (bufferClassName.equals("java.nio.ByteBufferAsLongBufferB")
+        || bufferClassName.equals("java.nio.ByteBufferAsLongBufferL")
+        || bufferClassName.equals("java.nio.ByteBufferAsLongBufferRB")
+        || bufferClassName.equals("java.nio.ByteBufferAsLongBufferRL")) {
+      byteBufferFieldName = "bb";
+
+    } else if (bufferClassName.equals("java.nio.DirectLongBufferU")
+        || bufferClassName.equals("java.nio.DirectLongBufferS")
+        || bufferClassName.equals("java.nio.DirectLongBufferRU")
+        || bufferClassName.equals("java.nio.DirectLongBufferRS")) {
+      byteBufferFieldName = "att";
+
+    } else {
+      throw new UnsupportedOperationException(String.format("LongBuffer type not supported: %s", bufferClassName));
+    }
+
+    dumpBuffer(getFieldValue(ByteBuffer.class, buffer, byteBufferFieldName));
+  }
+
+  /**
+   * Writes the contents of {@link ByteBuffer ByteBuffer} to the {@link PrintStream PrintStream}
+   * provided.  The dump consists of a sequence of lines where each line is the dump of a 32-byte segment from
+   * the buffer and includes data in hexadecimal and in printable ASCII.  A sample dump is shown: <pre>{@code
+   * 00000000  00000000 00000000 00000000 00000023  A5000000 00000000 00000000 00000000  *...............# ................*
+   * 00000020  00000000 00000020 00000000 00000023  A5000000 00000000 00000000 00000000  *....... .......# ................*
+   * 00000040-00000C7F  duplicates above                                                 *                                 *
+   * 00000C80  00000000 00000020 00000000 00000351  00000000 00000000 00000000 00000000  *....... .......Q ................*
+   * 00000CA0  00000000 00000000 00000000 00000000  00000000 00000000 00000000 00000000  *................ ................*
+   * 00000CC0-00FFFFDF  duplicates above                                                 *                                 *
+   * 00FFFFE0  00000000 00000000 00000000 00000000  00000000 00000000 00000000 00000000  *................ ................*
+   * }</pre>
+   * <p>
+   * For a <i>direct</i> {@code ByteBuffer}, this method attempts to access the value of an
+   * internal field.  Failure to access this field does not prevent this method from dumping
+   * the {@code ByteBuffer}.
+   *
+   * @param buffer the {@code ByteBuffer} to dump; the buffer is printed from position zero (0) through
+   *               the buffer limit using a <i>view</i> over the buffer
+   */
+  public void dumpBuffer(ByteBuffer buffer) {
+    requireNonNull(buffer, "buffer");
+
+    if (wasDumped(buffer)) {
+      return;
+    }
+
+    printStream.format("%s    ByteOrder=%s; capacity=%d (0x%<X); limit=%d (0x%<X); position=%d (0x%<X)",
+        linePrefix, buffer.order(), buffer.capacity(), buffer.limit(), buffer.position());
+    if (buffer.isDirect()) {
+      try {
+        long address = getFieldValue(Long.class, buffer, "address", true);
+        printStream.format("; address=0x%X%n", address);
+      } catch (FieldInaccessibleException e) {
+        printStream.println();
+      }
+    } else {
+      printStream.println();
+    }
+
+    ByteBuffer view = buffer.asReadOnlyBuffer();
+    view.clear();
+
+    dumpBufferInternal(view);
+  }
+
+  /**
+   * Writes the contents of {@code byte[]} to the {@link PrintStream PrintStream}
+   * provided.  The dump consists of a sequence of lines where each line is the dump of a 32-byte segment from
+   * the array and includes data in hexadecimal and in printable ASCII.  A sample dump is shown: <pre>{@code
+   * 00000000  00000000 00000000 00000000 00000023  A5000000 00000000 00000000 00000000  *...............# ................*
+   * 00000020  00000000 00000020 00000000 00000023  A5000000 00000000 00000000 00000000  *....... .......# ................*
+   * 00000040-00000C7F  duplicates above                                                 *                                 *
+   * 00000C80  00000000 00000020 00000000 00000351  00000000 00000000 00000000 00000000  *....... .......Q ................*
+   * 00000CA0  00000000 00000000 00000000 00000000  00000000 00000000 00000000 00000000  *................ ................*
+   * 00000CC0-00FFFFDF  duplicates above                                                 *                                 *
+   * 00FFFFE0  00000000 00000000 00000000 00000000  00000000 00000000 00000000 00000000  *................ ................*
+   * }</pre>
+   *
+   * @param bytes the {@code byte} array to dump
+   */
+  public void dump(byte[] bytes) {
+    requireNonNull(bytes, "bytes");
+    dumpBufferInternal(ByteBuffer.wrap(bytes));
+  }
+
+
+  private void dumpBufferInternal(ByteBuffer view) {
+    int segmentSize = 32;
+    int dumpFormatMax = 8 + 2 + 8 * (segmentSize/4) + (segmentSize/4 - 1) + (segmentSize/16 - 1);
+    int charFormatMax = segmentSize + (segmentSize/16 - 1);
+
+    StringBuilder dumpBuilder = new StringBuilder(128);
+    Formatter dumpFormatter = new Formatter(dumpBuilder);
+    StringBuilder charBuilder = new StringBuilder(128);
+
+    byte[][] segments = new byte[2][segmentSize];
+    int activeIndex = 0;
+    boolean previousSegmentSame = false;
+    while (view.hasRemaining()) {
+
+      if (!previousSegmentSame) {
+        flushDumpLine(printStream, dumpBuilder, charBuilder);
+      }
+
+      int offset = view.position();
+
+      byte[] activeSegment = segments[activeIndex];
+      int segmentLength = Math.min(activeSegment.length, view.remaining());
+      view.get(activeSegment, 0, segmentLength);
+
+      /*
+       * Except the first segment, perform duplicate segment handling. Duplicate segment data
+       * is not dumped; the offset of the first duplicate is retained and printed along with
+       * a terminating offset either once a non-duplicate segment or the end of the buffer is
+       * reached.
+       */
+      if (offset != 0) {
+        if (view.remaining() != 0 && Arrays.equals(activeSegment, segments[1 - activeIndex])) {
+          /* Suppress printing of a segment equal to the previous segment. */
+          if (!previousSegmentSame) {
+            dumpFormatter.format("%08X", offset);
+            previousSegmentSame = true;
+          }
+          continue;   /* Emit nothing for the 2nd through Nth segments having duplicate data. */
+
+        } else if (previousSegmentSame) {
+          /* No longer duplicated; complete duplication marker line and flush. */
+          dumpFormatter.format("-%08X  duplicates above", offset - 1);
+          dumpBuilder.append(new String(new char[dumpFormatMax - dumpBuilder.length()]).replace('\0', ' '));
+          charBuilder.append(new String(new char[charFormatMax]).replace('\0', ' '));
+          flushDumpLine(printStream, dumpBuilder, charBuilder);
+          previousSegmentSame = false;
+        }
+      }
+
+      dumpFormatter.format("%08X  ", offset);
+
+      /*
+       * Format the segment (or final fragment) data.  Include the character form of each
+       * byte if, and only if, it is both (7-bit) ASCII and not a control character.
+       */
+      for (int i = 0; i < segmentLength; i++) {
+        if (i != 0) {
+          addGroupSpace(i, dumpBuilder, charBuilder);
+        }
+
+        byte b = activeSegment[i];
+        dumpFormatter.format("%02X", b & 0xFF);
+        charBuilder.append(ASCII_ENCODER.canEncode((char) b) && !Character.isISOControl(b) ? (char) b : '.');
+      }
+
+      activeIndex = 1 - activeIndex;
+    }
+
+    /*
+     * If the last segment was not a full segment, complete formatting the dump line
+     * using filler so separators and such are aligned.
+     */
+    int segmentOffset = view.position() % segmentSize;
+    if (segmentOffset != 0) {
+      /* Fill the remaining output buffer */
+      for (int i = segmentOffset; i < segmentSize; i++) {
+        addGroupSpace(i, dumpBuilder, charBuilder);
+        dumpBuilder.append("  ");     /* Empty data */
+        charBuilder.append(' ');
+      }
+    }
+
+    flushDumpLine(printStream, dumpBuilder, charBuilder);
+  }
+
+  /**
+   * {@link CharsetEncoder CharsetEncoder} used to test bytes for printability.
+   */
+  private static final CharsetEncoder ASCII_ENCODER = StandardCharsets.US_ASCII.newEncoder();
+
+  private static void addGroupSpace(int i, StringBuilder dumpBuilder, StringBuilder charBuilder) {
+    if (i % 4 == 0) {
+      dumpBuilder.append(' ');
+    }
+    if (i % 16 == 0) {
+      dumpBuilder.append(' ');
+      charBuilder.append(' ');
+    }
+  }
+
+  /**
+   * Emit a dump line and prepare the buffers for the next.
+   *
+   * @param out the {@code PrintStream} to which the dump line is written
+   * @param dumpBuilder the {@code StringBuilder} into which the hex portion of the dump line, including
+   *                    the displacement, are recorded
+   * @param charBuilder the {@code StringBuilder} into which the ASCII portion of the dump line is recorded
+   */
+  private void flushDumpLine(PrintStream out, StringBuilder dumpBuilder, StringBuilder charBuilder) {
+    if (dumpBuilder.length() != 0) {
+      out.append(linePrefix).append(dumpBuilder).append("  ").append('*').append(charBuilder).append('*');
+      out.println();
+      dumpBuilder.setLength(0);
+      charBuilder.setLength(0);
+    }
+  }
+
+  /**
+   * Gets the value of the designated field from the object instance provided.  This method expects
+   * a non-{@code null} value in the field.
+   *
+   * @param expectedType the type to which the fetched value is cast
+   * @param instance the instance from which the value is fetched
+   * @param fieldName the name of the field in {@code instance} holding the value
+   * @param <V> the declared type of the returned value
+   * @param <T> the declared type of the object from which the value is obtained
+   *
+   * @return the value of the named field
+   *
+   * @throws FieldInaccessibleException if an error occurs while attempting to access the field
+   * @throws AssertionError if the field {@code fieldName} contains {@code null}
+   */
+  private <V, T> V getFieldValue(Class<V> expectedType, T instance, String fieldName) {
+    return getFieldValue(expectedType, instance, fieldName, false);
+  }
+
+  /**
+   * Gets the value of the designated field from the object instance provided.  This method expects
+   * a non-{@code null} value in the field.
+   *
+   * @param <V> the declared type of the returned value
+   * @param <T> the declared type of the object from which the value is obtained
+   *
+   * @param expectedType the type to which the fetched value is cast
+   * @param instance the instance from which the value is fetched
+   * @param fieldName the name of the field in {@code instance} holding the value
+   * @param quiet if {@code true}, suppress the informational message related to the value fetch and permit
+   *              the return of a {@code null} value
+   *
+   * @return the value of the named field; may be {@code null} if, and only if, {@code quiet} is {@code true}
+   *
+   * @throws FieldInaccessibleException if an error occurs while attempting to access the field
+   * @throws AssertionError if the field {@code fieldName} contains {@code null}
+   */
+  private <V, T> V getFieldValue(Class<V> expectedType, T instance, String fieldName, boolean quiet) {
+    V fieldValue;
+    try {
+      /*
+       * Traverse the current and super class definitions looking for the named field.
+       */
+      Class<?> fieldHoldingClass = instance.getClass();
+      NoSuchFieldException firstFault = null;
+      Field fieldDef = null;
+      do {
+        try {
+          fieldDef = fieldHoldingClass.getDeclaredField(fieldName);
+        } catch (NoSuchFieldException e) {
+          if (firstFault == null) {
+            firstFault = e;
+          }
+          fieldHoldingClass = fieldHoldingClass.getSuperclass();
+          if (fieldHoldingClass == null) {
+            throw firstFault;
+          }
+        }
+      } while (fieldDef == null);
+      fieldDef.setAccessible(true);
+      fieldValue = expectedType.cast(fieldDef.get(instance));
+      if (!quiet) {
+        if (fieldValue == null) {
+          throw new AssertionError(String.format("%s.%s is null; expecting %s instance",
+              instance.getClass().getSimpleName(), fieldName, expectedType.getSimpleName()));
+        }
+        printStream.format("%s    %s.%s -> %s%n",
+            linePrefix, instance.getClass().getSimpleName(), fieldName, getObjectId(fieldValue));
+      }
+
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new FieldInaccessibleException(String.format("Unable to get '%s' field from %s instance: %s",
+          fieldName, instance.getClass().getName(), e), e);
+    }
+    return fieldValue;
+  }
+
+  /**
+   * Gets an object identifier similar to the one produced by {@link Object#toString() Object.toString}.
+   *
+   * @param o the object for which the identifier is generated
+   *
+   * @return the object identifier
+   */
+  private static String getObjectId(Object o) {
+    if (o == null) {
+      return "null@0";
+    }
+    return o.getClass().getName() + "@" + Integer.toHexString(System.identityHashCode(o));
+  }
+
+  /**
+   * Thrown if reflective access to a required internal field fails.
+   */
+  public static final class FieldInaccessibleException extends UnsupportedOperationException {
+    private static final long serialVersionUID = -2136579828792539023L;
+
+    public FieldInaccessibleException(String message, Throwable cause) {
+      super(message, cause);
+    }
+  }
+}

--- a/tools/src/main/java/org/terracotta/utilities/logging/LoggerBridge.java
+++ b/tools/src/main/java/org/terracotta/utilities/logging/LoggerBridge.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2020 Terracotta, Inc., a Software AG company.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.utilities.logging;
+
+import org.slf4j.Logger;
+import org.slf4j.event.Level;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.AbstractMap;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Bridge to permit variable-level use of SLF4j.
+ * <p>
+ * This class maintains a static reference to the {@code LoggerBridge} instances created
+ * by {@link #getInstance(Logger, Level)}.
+ */
+public final class LoggerBridge {
+  private static final Map<Map.Entry<Logger, Level>, LoggerBridge> INSTANCES = new HashMap<>();
+
+  private final Logger delegate;
+  private final Level level;
+  private final MethodHandle isLevelEnabled;
+  private final MethodHandle log;
+  private final MethodHandle logThrowable;
+
+  /**
+   * Creates or gets the {@code LoggerBridge} instance for the delegate {@link Logger} and {@link Level}.
+   *
+   * @param delegate the {@code Logger} to which logging calls are delegated
+   * @param level    the {@code Level} at which the returned {@code LoggingBridge} logs
+   * @return a {@code LoggingBridge} instance
+   */
+  public static LoggerBridge getInstance(Logger delegate, Level level) {
+    return INSTANCES.computeIfAbsent(new AbstractMap.SimpleImmutableEntry<>(delegate, level),
+        e -> new LoggerBridge(e.getKey(), e.getValue()));
+  }
+
+  /**
+   * Creates a {@code LoggerBridge} instance sending logging calls to the
+   * designated {@link Logger} at the specified level.
+   *
+   * @param delegate the delegate {@code Logger}
+   * @param level    the level at which the {@link #log} method records
+   */
+  private LoggerBridge(Logger delegate, Level level) {
+    this.delegate = requireNonNull(delegate, "delegate");
+    this.level = requireNonNull(level, "level");
+
+    String levelName = level.name().toLowerCase(Locale.ROOT);
+    MethodHandles.Lookup lookup = MethodHandles.publicLookup();
+    MethodType type;
+
+    /*
+     * Find the boolean 'is<Level>Enabled'() method.
+     */
+    MethodHandle isLevelEnabled;
+    type = MethodType.methodType(boolean.class);
+    try {
+      isLevelEnabled = lookup.findVirtual(Logger.class,
+          "is" + levelName.substring(0, 1).toUpperCase(Locale.ROOT) + levelName.substring(1) + "Enabled", type);
+    } catch (NoSuchMethodException | IllegalAccessException e) {
+      isLevelEnabled = null;
+      delegate.error("Unable to resolve '{} {}({})' method on {}; will log at INFO level",
+          type.returnType(), levelName, type.parameterList(), Logger.class, e);
+    }
+    this.isLevelEnabled = isLevelEnabled;
+
+    /*
+     * Find the void '<level>'(String, Object...) method.
+     */
+    MethodHandle log;
+    type = MethodType.methodType(void.class, String.class, Object[].class);
+    try {
+      log = lookup.findVirtual(Logger.class, levelName, type);
+    } catch (NoSuchMethodException | IllegalAccessException e) {
+      log = null;
+      delegate.error("Unable to resolve '{} {}({})' method on {}; will log at INFO level",
+          type.returnType(), levelName, type.parameterList(), Logger.class, e);
+    }
+    this.log = log;
+
+    /*
+     * Find the void '<level>'(String, Throwable) method.
+     */
+    MethodHandle logThrowable;
+    type = MethodType.methodType(void.class, String.class, Throwable.class);
+    try {
+      logThrowable = lookup.findVirtual(Logger.class, levelName, type);
+    } catch (NoSuchMethodException | IllegalAccessException e) {
+      logThrowable = null;
+      delegate.error("Unable to resolve '{} {}({})' method on {}; will log at INFO level",
+          type.returnType(), levelName, type.parameterList(), Logger.class, e);
+    }
+    this.logThrowable = logThrowable;
+  }
+
+  /**
+   * Checks if the delegate logger is active for the configured level.
+   *
+   * @return {@code true} if the delegate logger is configured to record events of the level
+   * of this {@code LoggerBridge}
+   */
+  public boolean isLevelEnabled() {
+    if (isLevelEnabled != null) {
+      try {
+        return (boolean)isLevelEnabled.invokeExact(delegate);
+      } catch (Throwable throwable) {
+        delegate.error("Failed to call {}; presuming {} is enabled", isLevelEnabled, level, throwable);
+        return true;
+      }
+    } else {
+      return delegate.isInfoEnabled();
+    }
+  }
+
+  /**
+   * Submits a log event to the delegate logger at the level of this {@code LoggerBridge}.
+   * If the virtual call to the log method fails, the log event is recorded at the {@code INFO}
+   * level.
+   *
+   * @param format    the log message format
+   * @param arguments the arguments for the message
+   */
+  public void log(String format, Object... arguments) {
+    if (log != null) {
+      try {
+        log.invokeExact(delegate, format, arguments);
+      } catch (Throwable throwable) {
+        delegate.error("Failed to call {}; logging at INFO level", log, throwable);
+        delegate.info(format, arguments);
+      }
+    } else {
+      delegate.info(format, arguments);
+    }
+  }
+
+  /**
+   * Submits a log event to the delegate logger at the level of this {@code LoggerBridge}.
+   * If the virtual call to the log method fails, the log event is recorded at the {@code INFO}
+   * level.
+   *
+   * @param message the log message format
+   * @param t the {@code Throwable} to log with {@code message}
+   */
+  public void log(String message, Throwable t) {
+    if (logThrowable != null) {
+      try {
+        logThrowable.invokeExact(delegate, message, t);
+      } catch (Throwable throwable) {
+        delegate.error("Failed to call {}; logging at INFO level", logThrowable, throwable);
+        delegate.info(message, t);
+      }
+    } else {
+      delegate.info(message, t);
+    }
+  }
+}

--- a/tools/src/main/java/org/terracotta/utilities/logging/LoggingOutputStream.java
+++ b/tools/src/main/java/org/terracotta/utilities/logging/LoggingOutputStream.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2020 Terracotta, Inc., a Software AG company.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.utilities.logging;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import org.slf4j.Logger;
+import org.slf4j.event.Level;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.WrongMethodTypeException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Implements an {@code OutputStream} that forwards lines written to it to
+ * a {@link Logger} at a specified level.  Bytes are accumulated by this
+ * {@code OutputStream} until a {@link System#lineSeparator()} value is found;
+ * once the line ending is found, the line is flushed to the logger.
+ */
+public class LoggingOutputStream extends OutputStream {
+
+  public static final int DEFAULT_BUFFER_SIZE = 4096;
+
+  private final Logger logger;
+  private final MethodHandle handle;
+  private final boolean twoByteLineSeparator;
+  private final byte eol;
+  private final byte eolLeader;
+
+  @SuppressFBWarnings(value = "SS_SHOULD_BE_STATIC", justification = "Awaiting option to disable autoFlush")
+  private final boolean autoFlush = true;
+
+  private volatile boolean closed = false;
+  private byte[] buffer = new byte[DEFAULT_BUFFER_SIZE];
+  private int bufferSize = DEFAULT_BUFFER_SIZE;
+  private int byteCount = 0;
+  private boolean haveLeader = false;
+
+  /**
+   * Creates a new {@code LoggingOutputStream} writing to the provided logger and the
+   * specified level.
+   * @param logger the SLF4J {@code Logger} instance to which the stream should write
+   * @param level the SLF4J level at which the stream is recorded to {@code logger}
+   */
+  public LoggingOutputStream(Logger logger, Level level) {
+    this.logger = logger;
+    this.handle = getHandle(level);
+
+    String lineSeparator = System.lineSeparator();
+    this.twoByteLineSeparator = lineSeparator.length() == 2;
+    this.eol = (byte)lineSeparator.charAt(lineSeparator.length() - 1);
+    this.eolLeader = (byte)(this.twoByteLineSeparator ? lineSeparator.charAt(0) : '\0');  }
+
+  @Override
+  public void write(int b) throws IOException {
+    synchronized (this) {
+      checkOpen();
+
+      if (twoByteLineSeparator && (byte)b == eolLeader) {
+        haveLeader = true;        // Remember the leader; processed along with the next byte
+      } else {
+        if ((byte)b == eol) {
+          if (autoFlush) {
+            haveLeader = false;   // Awaited EOL received; leader consumed with EOL in flush
+            flushInternal();
+            return;
+          }
+        }
+
+        // Non-flushed EOL or a non-EOL byte, emit held leader
+        if (haveLeader) {
+          appendByte(eolLeader);
+          haveLeader = false;
+        }
+        appendByte((byte)b);
+      }
+    }
+  }
+
+  @Override
+  public void flush() throws IOException {
+    synchronized (this) {
+      checkOpen();
+      flushInternal();
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    synchronized (this) {
+      flushInternal();
+      closed = true;
+    }
+  }
+
+  private void flushInternal() throws IOException {
+    if (haveLeader) {
+      // Flush called before EOL appended or leader has no EOL
+      appendByte(eolLeader);
+      haveLeader = false;
+    }
+
+    if (byteCount == 0) {
+      return;
+    }
+
+    log(new String(buffer, 0, byteCount, StandardCharsets.UTF_8));
+    byteCount = 0;
+  }
+
+  private void log(String line) throws IOException {
+    try {
+      handle.invokeExact(logger, line);
+    } catch (WrongMethodTypeException e) {
+      throw new AssertionError(String.format("Unexpected error calling %s: %s", handle, e), e);
+    } catch (Throwable throwable) {
+      if (throwable instanceof Error) {
+        throw (Error)throwable;
+      } else if (throwable instanceof RuntimeException) {
+        throw (RuntimeException)throwable;
+      }
+      throw new IOException(String.format("Unexpected error calling %s: %s", handle, throwable), throwable);
+    }
+  }
+
+  private void appendByte(byte b) {
+    if (byteCount == bufferSize) {
+      int newBufferSize = bufferSize + DEFAULT_BUFFER_SIZE;
+      byte[] newBuffer = new byte[newBufferSize];
+      System.arraycopy(buffer, 0, newBuffer, 0, byteCount);
+      buffer = newBuffer;
+      bufferSize = newBufferSize;
+    }
+
+    buffer[byteCount++] = b;
+  }
+
+  private void checkOpen() throws IOException {
+    if (closed) {
+      throw new IOException("stream closed");
+    }
+  }
+
+  private MethodHandle getHandle(Level level) {
+    String levelName = level.name().toLowerCase();
+    MethodHandles.Lookup lookup = MethodHandles.publicLookup();
+    MethodType type = MethodType.methodType(void.class, String.class);
+    try {
+      return lookup.findVirtual(Logger.class, levelName, type);
+    } catch (NoSuchMethodException | IllegalAccessException e) {
+      throw new AssertionError(String.format("Unable to resolve '%s %s(%s)' method on %s", type.returnType(), levelName, type.parameterList(), Logger.class), e);
+    }
+  }
+}

--- a/tools/src/test/java/org/terracotta/utilities/io/CapturedPrintStreamTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/io/CapturedPrintStreamTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Terracotta, Inc., a Software AG company.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.utilities.io;
+
+import org.junit.Test;
+
+import java.io.BufferedReader;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+/**
+ * Basic tests for {@link CapturedPrintStream}.
+ */
+public class CapturedPrintStreamTest {
+
+  @Test
+  public void testEmpty() throws Exception {
+    BufferedReader reader = CapturedPrintStream.getInstance().getReader();
+    assertThat(reader.readLine(), is(nullValue()));
+  }
+
+  @Test
+  public void testNoLineEnd() throws Exception {
+    CapturedPrintStream stream = CapturedPrintStream.getInstance();
+    stream.print("foo");
+    BufferedReader reader = stream.getReader();
+    assertThat(reader.readLine(), is("foo"));
+    assertThat(reader.readLine(), is(nullValue()));
+  }
+
+  @Test
+  public void testTwoLines() throws Exception {
+    CapturedPrintStream stream = CapturedPrintStream.getInstance();
+    stream.println("foo");
+    stream.println("bar");
+    BufferedReader reader = stream.getReader();
+    assertThat(reader.readLine(), is("foo"));
+    assertThat(reader.readLine(), is("bar"));
+    assertThat(reader.readLine(), is(nullValue()));
+  }
+}

--- a/tools/src/test/java/org/terracotta/utilities/io/NullOutputStreamTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/io/NullOutputStreamTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Terracotta, Inc., a Software AG company.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.utilities.io;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.terracotta.utilities.test.matchers.ThrowsMatcher.threw;
+
+/**
+ * Tests the basics of {@link NullOutputStream}.
+ */
+public class NullOutputStreamTest {
+
+  @Test
+  public void testWriteInt() throws Exception {
+    OutputStream stream = new NullOutputStream();
+    stream.write('a');
+
+    stream.close();
+    assertThat(() -> stream.write('a'), threw(instanceOf(IOException.class)));
+  }
+
+  @Test
+  public void testByteArray() throws Exception {
+    OutputStream stream = new NullOutputStream();
+    stream.write(new byte[0]);
+    stream.write(new byte[] {0, 1});
+
+    stream.close();
+    assertThat(() -> stream.write(new byte[0]), threw(instanceOf(IOException.class)));
+  }
+
+  @Test
+  public void testByteArrayRange() throws Exception {
+    OutputStream stream = new NullOutputStream();
+    stream.write(new byte[0], 0, 0);
+    stream.write(new byte[] {0, 1}, 1, 1);
+    assertThat(() -> stream.write(new byte[0], 1, 1), threw(instanceOf(IndexOutOfBoundsException.class)));
+    assertThat(() -> stream.write(null, 0, 1), threw(instanceOf(NullPointerException.class)));
+
+    stream.close();
+    assertThat(() -> stream.write(new byte[0], 0, 0), threw(instanceOf(IOException.class)));
+  }
+
+  @Test
+  public void testFlush() throws Exception {
+    OutputStream stream = new NullOutputStream();
+    stream.flush();
+  }
+}

--- a/tools/src/test/java/org/terracotta/utilities/logging/LoggerBridgeTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/logging/LoggerBridgeTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 Terracotta, Inc., a Software AG company.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.utilities.logging;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+
+/**
+ * Basic tests for {@link LoggerBridge}.
+ * This class relies on Logback ...
+ */
+public class LoggerBridgeTest {
+
+  @Test
+  public void testInstanceTest() {
+    Logger testLogger = LoggerFactory.getLogger("testLogger");
+    Logger alternateLogger = LoggerFactory.getLogger("alternateLogger");
+
+    LoggerBridge infoTestBridge = LoggerBridge.getInstance(testLogger, Level.INFO);
+    assertThat(LoggerBridge.getInstance(testLogger, Level.INFO), is(sameInstance(infoTestBridge)));
+    assertThat(LoggerBridge.getInstance(testLogger, Level.WARN), is(not(sameInstance(infoTestBridge))));
+
+    assertThat(LoggerBridge.getInstance(alternateLogger, Level.INFO), is(not(sameInstance(infoTestBridge))));
+  }
+
+  @Test
+  public void testLogging() {
+    LoggerContext context = (LoggerContext)LoggerFactory.getILoggerFactory();
+
+    ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.setContext(context);
+    appender.start();
+
+    Logger logger = LoggerFactory.getLogger("testLogger");
+    {
+      ch.qos.logback.classic.Logger logbackLogger = (ch.qos.logback.classic.Logger)logger;
+      logbackLogger.addAppender(appender);
+      logbackLogger.setLevel(ch.qos.logback.classic.Level.DEBUG);
+      logbackLogger.setAdditive(false);
+    }
+
+    LoggerBridge infoBridge = LoggerBridge.getInstance(logger, Level.INFO);
+    assertThat(infoBridge.isLevelEnabled(), is(true));
+    infoBridge.log("Message with {} substitution", "a");
+    assertThat(appender.list, hasSize(1));
+    ILoggingEvent loggingEvent = appender.list.get(0);
+    assertThat(loggingEvent.toString(), containsString("Message with a substitution"));
+    assertThat(loggingEvent.getLevel(), is(ch.qos.logback.classic.Level.INFO));
+    assertThat(loggingEvent.getThrowableProxy(), is(nullValue()));
+
+    appender.list.clear();
+
+    LoggerBridge traceBridge = LoggerBridge.getInstance(logger, Level.TRACE);
+    assertThat(traceBridge.isLevelEnabled(), is(false));
+    traceBridge.log("Message with {} substitution", "a");
+    assertThat(appender.list, is(empty()));
+
+    appender.list.clear();
+
+    infoBridge.log("Message with exception", new IllegalArgumentException());
+    assertThat(appender.list, hasSize(1));
+    loggingEvent = appender.list.get(0);
+    assertThat(loggingEvent.toString(), containsString("Message with exception"));
+    assertThat(loggingEvent.getThrowableProxy(), is(notNullValue()));
+    assertThat(loggingEvent.getThrowableProxy().getClassName(), is(IllegalArgumentException.class.getName()));
+  }
+}

--- a/tools/src/test/java/org/terracotta/utilities/logging/LoggingOutputStreamTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/logging/LoggingOutputStreamTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Terracotta, Inc., a Software AG company.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.utilities.logging;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+
+import java.io.PrintStream;
+import java.util.Arrays;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.stringContainsInOrder;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Basic tests for {@link LoggingOutputStream}.
+ */
+public class LoggingOutputStreamTest {
+
+  @Test
+  public void testLogback() {
+    LoggerContext context = (LoggerContext)LoggerFactory.getILoggerFactory();
+
+    ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.setContext(context);
+    appender.start();
+
+    Logger logger = LoggerFactory.getLogger("testLogger");
+    {
+      ch.qos.logback.classic.Logger logbackLogger = (ch.qos.logback.classic.Logger)logger;
+      logbackLogger.addAppender(appender);
+      logbackLogger.setLevel(ch.qos.logback.classic.Level.DEBUG);
+      logbackLogger.setAdditive(false);
+    }
+
+    LoggingOutputStream loggingOutputStream = new LoggingOutputStream(logger, Level.INFO);
+    PrintStream out = new PrintStream(loggingOutputStream);
+
+    out.format("Recording to %s via %s%n", appender, logger);
+
+    assertThat(appender.list, hasSize(1));
+    assertThat(appender.list.get(0).toString(),
+        stringContainsInOrder(Arrays.asList("Recording to", appender.toString(), "via", logger.toString())));
+  }
+}

--- a/tools/src/test/java/org/terracotta/utilities/logging/LoggingOutputStreamTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/logging/LoggingOutputStreamTest.java
@@ -27,7 +27,9 @@ import org.slf4j.event.Level;
 import java.io.PrintStream;
 import java.util.Arrays;
 
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.stringContainsInOrder;
 import static org.junit.Assert.assertThat;
 
@@ -53,12 +55,19 @@ public class LoggingOutputStreamTest {
     }
 
     LoggingOutputStream loggingOutputStream = new LoggingOutputStream(logger, Level.INFO);
-    PrintStream out = new PrintStream(loggingOutputStream);
-
-    out.format("Recording to %s via %s%n", appender, logger);
-
+    try (PrintStream out = new PrintStream(loggingOutputStream)) {
+      out.format("Recording to %s via %s%n", appender, logger);
+    }
     assertThat(appender.list, hasSize(1));
     assertThat(appender.list.get(0).toString(),
         stringContainsInOrder(Arrays.asList("Recording to", appender.toString(), "via", logger.toString())));
+
+    appender.list.clear();
+
+    loggingOutputStream = new LoggingOutputStream(logger, Level.TRACE);
+    try (PrintStream out = new PrintStream(loggingOutputStream)) {
+      out.format("Recording to %s via %s%n", appender, logger);
+    }
+    assertThat(appender.list, is(empty()));
   }
 }


### PR DESCRIPTION
This commit adds several classes to aid generation of diagnostic output:

* `LoggerBridge` and `LoggingOutputStream` to help with logging scenarios not easily addressed by SLF4J
* `CapturedPrintStream` and `NullOutputStream` to help in bridging stream output to the non-stream world
* `DumpUtility` to support "dumping" `Buffer` variants for visual examination