### PR TITLE
TemporaryFolder from JUnit 4.13.1

### DIFF
--- a/test-tools/README.md
+++ b/test-tools/README.md
@@ -7,13 +7,17 @@ those tools borrowed from elsewhere.
 
 ### `TemporaryFolder` from JUnit 4
 
-The version of `org.junit.rules.TemporaryFolder` (at commit `038f7518fc1018b26df608e3e5dce6db4611be29`, tag `r4.13` 
+* The version of `org.junit.rules.TemporaryFolder` (at commit `038f7518fc1018b26df608e3e5dce6db4611be29`, tag `r4.13` 
 corresponding to the version released in JUnit 4.13) was lifted from
 the JUnit 4 code base (<https://github.com/junit-team/junit4>) to pick up changes related
 to issue [_TemporaryFolder doesn't work for parallel test execution in several JVMs_ #1223](https://github.com/junit-team/junit4/issues/1223).
 Other than relocating the package from `org.junit.rules` to `org.terracotta.org.junit.rules`
 (and adding necessary imports), the captured files are unchanged.  Its use is governed
 by `LICENSE-junit.txt` found at <https://raw.githubusercontent.com/junit-team/junit4/master/LICENSE-junit.txt>.
+
+* The versions of `org.junit.tules.TemporaryFolder` and `org.junit.rules.TempFolderRuleTest` (at commit
+`1b683f4ec07bcfa40149f086d32240f805487e66`, tag `r4.13.1`) were lifted to pick up changes related to
+the resolution of CVE-2020-15250.
 
 **NOTE:** To limit changes to the files obtained from the JUnit code base to the absolute minimum, 
 the Terracotta copyright header is intentionally omitted and SpotBugs/FindBugs is intentionally suppressed.

--- a/test-tools/src/main/java/org/terracotta/org/junit/rules/TemporaryFolder.java
+++ b/test-tools/src/main/java/org/terracotta/org/junit/rules/TemporaryFolder.java
@@ -5,6 +5,9 @@ import org.junit.rules.ExternalResource;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Array;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 import static org.junit.Assert.fail;
 
@@ -49,7 +52,7 @@ public class TemporaryFolder extends ExternalResource {
     private static final String TMP_PREFIX = "junit";
 
     /**
-     * Create a temporary folder which uses system default temporary-file 
+     * Create a temporary folder which uses system default temporary-file
      * directory to create temporary resources.
      */
     public TemporaryFolder() {
@@ -88,7 +91,7 @@ public class TemporaryFolder extends ExternalResource {
 
     /**
      * Builds an instance of {@link TemporaryFolder}.
-     * 
+     *
      * @since 4.13
      */
     public static class Builder {
@@ -230,7 +233,45 @@ public class TemporaryFolder extends ExternalResource {
         return createTemporaryFolderIn(getRoot());
     }
 
-    private File createTemporaryFolderIn(File parentFolder) throws IOException {
+    private static File createTemporaryFolderIn(File parentFolder) throws IOException {
+        try {
+            return createTemporaryFolderWithNioApi(parentFolder);
+        } catch (ClassNotFoundException ignore) {
+            // Fallback for Java 5 and 6
+            return createTemporaryFolderWithFileApi(parentFolder);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof IOException) {
+                throw (IOException) cause;
+            }
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            }
+            IOException exception = new IOException("Failed to create temporary folder in " + parentFolder);
+            exception.initCause(cause);
+            throw exception;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create temporary folder in " + parentFolder, e);
+        }
+    }
+
+    private static File createTemporaryFolderWithNioApi(File parentFolder) throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Class<?> filesClass = Class.forName("java.nio.file.Files");
+        Object fileAttributeArray = Array.newInstance(Class.forName("java.nio.file.attribute.FileAttribute"), 0);
+        Class<?> pathClass = Class.forName("java.nio.file.Path");
+        Object tempDir;
+        if (parentFolder != null) {
+            Method createTempDirectoryMethod = filesClass.getDeclaredMethod("createTempDirectory", pathClass, String.class, fileAttributeArray.getClass());
+            Object parentPath = File.class.getDeclaredMethod("toPath").invoke(parentFolder);
+            tempDir = createTempDirectoryMethod.invoke(null, parentPath, TMP_PREFIX, fileAttributeArray);
+        } else {
+            Method createTempDirectoryMethod = filesClass.getDeclaredMethod("createTempDirectory", String.class, fileAttributeArray.getClass());
+            tempDir = createTempDirectoryMethod.invoke(null, TMP_PREFIX, fileAttributeArray);
+        }
+        return (File) pathClass.getDeclaredMethod("toFile").invoke(tempDir);
+    }
+
+    private static File createTemporaryFolderWithFileApi(File parentFolder) throws IOException {
         File createdFolder = null;
         for (int i = 0; i < TEMP_DIR_ATTEMPTS; ++i) {
             // Use createTempFile to get a suitable folder name.
@@ -288,7 +329,7 @@ public class TemporaryFolder extends ExternalResource {
         if (folder == null) {
             return true;
         }
-        
+
         return recursiveDelete(folder);
     }
 

--- a/test-tools/src/test/java/org/terracotta/org/junit/rules/TempFolderRuleTest.java
+++ b/test-tools/src/test/java/org/terracotta/org/junit/rules/TempFolderRuleTest.java
@@ -1,17 +1,23 @@
 package org.terracotta.org.junit.rules;
 
 import org.junit.After;
+import org.junit.AssumptionViolatedException;
 import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Array;
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.experimental.results.PrintableResult.testResult;
@@ -179,6 +185,34 @@ public class TempFolderRuleTest {
         folder.create();
         folder.delete();
         assertFalse(folder.getRoot().exists());
+    }
+
+    @Test
+    public void tempFolderIsOnlyAccessibleByOwner() throws IOException {
+        TemporaryFolder folder = new TemporaryFolder();
+        folder.create();
+
+        Set<String> expectedPermissions = new TreeSet<String>(Arrays.asList("OWNER_READ", "OWNER_WRITE", "OWNER_EXECUTE"));
+        Set<String> actualPermissions = getPosixFilePermissions(folder.getRoot());
+        assertEquals(expectedPermissions, actualPermissions);
+    }
+
+    private Set<String> getPosixFilePermissions(File root) {
+        try {
+            Class<?> pathClass = Class.forName("java.nio.file.Path");
+            Object linkOptionArray = Array.newInstance(Class.forName("java.nio.file.LinkOption"), 0);
+            Class<?> filesClass = Class.forName("java.nio.file.Files");
+            Object path = File.class.getDeclaredMethod("toPath").invoke(root);
+            Method posixFilePermissionsMethod = filesClass.getDeclaredMethod("getPosixFilePermissions", pathClass, linkOptionArray.getClass());
+            Set<?> permissions = (Set<?>) posixFilePermissionsMethod.invoke(null, path, linkOptionArray);
+            SortedSet<String> convertedPermissions = new TreeSet<String>();
+            for (Object item : permissions) {
+                convertedPermissions.add(item.toString());
+            }
+            return convertedPermissions;
+        } catch (Exception e) {
+            throw new AssumptionViolatedException("Test requires at least Java 1.7", e);
+        }
     }
 
     public static class NameClashes {


### PR DESCRIPTION
This commit picks up changes made to `TemporaryFolder` in JUnit 4.13.1 addressing CVE-2020-15250.