### PR TITLE
Correct `NetStat` processing for older versions of `lsof`

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,9 +26,20 @@ resources:
 jobs:
 - template: build-templates/maven-common.yml@templates  
   parameters:
-    jobName: 'Linux'
+    jobName: 'Linux_Hosted'
     
 - template: build-templates/maven-common.yml@templates
   parameters:
+    jobName: 'Linux_OnPrem'
+    pool: tc_linux_pool
+
+- template: build-templates/maven-common.yml@templates
+  parameters:
     vmImage: 'windows-latest'
-    jobName: 'Windows'
+    jobName: 'Windows_Hosted'
+
+- template: build-templates/maven-common.yml@templates
+  parameters:
+    jobName: 'Windows_OnPrem'
+    pool: tc_windows_pool
+

--- a/port-chooser/src/main/java/org/terracotta/utilities/test/net/NetStat.java
+++ b/port-chooser/src/main/java/org/terracotta/utilities/test/net/NetStat.java
@@ -530,7 +530,7 @@ public class NetStat {
       "-nP",          // Use numeric IP addresses; use numeric ports
       "-iTCP",        // Match only TCP connections
       "-F",           // Field list ...
-      "0pPRgLnTtc",   // ... see 'parseLsof' for description
+      "0pPRgLnTftc",  // ... see 'parseLsof' for description
       "+c0",          // Use expanded COMMAND value
       "-w"            // Suppress warnings
   };


### PR DESCRIPTION
This commit stream adds the `f` field designator (file descriptor) to the `lsof` `-F` option value to force the presence of the `f` (file descriptor) field in the `lsof` output used by `NetStat`.  (Newer versions include the field regardless of the presence of the `f` designator.)

This commit stream also attempts to disable the diagnostic port busy check (making use of `NetStat`) done by `PortManger` if `NetStat` fails.  (The typical usage model for `PortManager` results in multiple calls to `NetStat` and an environmental failure -- like an unexpected `lsof` output format -- can result in considerable noise.)