### PR TITLE
Correct Diagnostics.getAllThreads behavior

### DIFF
--- a/test-tools/src/main/java/org/terracotta/utilities/test/Diagnostics.java
+++ b/test-tools/src/main/java/org/terracotta/utilities/test/Diagnostics.java
@@ -322,9 +322,9 @@ public final class Diagnostics {
   public static Thread[] getAllThreads() {
     ThreadGroup root = rootGroup();
     Thread[] threads;
-    int estThreadCount = root.activeCount();
+    int estThreadCount = 1 + root.activeCount();
     int actualThreadCount;
-    while ((actualThreadCount = root.enumerate(threads = new Thread[estThreadCount])) == estThreadCount) {
+    while ((actualThreadCount = root.enumerate(threads = new Thread[estThreadCount])) >= estThreadCount) {
       estThreadCount += 1 + estThreadCount * 20 / 100;
     }
     threads = Arrays.copyOf(threads, actualThreadCount);


### PR DESCRIPTION
The documentation for `ThreadGroup.enumerate(Thread[], boolean)` says:
***If it is critical to obtain every active thread in this thread group, the
caller should verify that the returned int value is strictly less than the
length of list.***  This commit changed the behavior of `getAllThreads` to
conform to thad admonition.