### PR TITLE
Add a more flexible GA build to test on Java 8 and 11 inside docker and on mac, lin and win

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,69 @@
+name: CI
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+#    branches:
+#      - master
+#      - lsof # just to be able to run all these builds on our own fork
+jobs:
+  with-docker:
+    name: Inside Container ${{matrix.java}}-zulu-centos
+    runs-on: ubuntu-latest
+    container: mcr.microsoft.com/java/jdk:${{matrix.java}}-zulu-centos
+    strategy:
+      matrix:
+        java: [ 8, 11 ]
+      fail-fast: false
+      max-parallel: 4
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Test with Maven
+        run: ./mvnw clean verify -V -B -D"maven.artifact.threads=64" -D"org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -D"disable-toolchain" -D"java.version=${{matrix.java}}" -D"inside-container=true"
+      - name: Upload Unit Test Results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: Unit Test Results (Container ${{matrix.java}}-zulu-centos)
+          path: "**/target/surefire-reports/**"
+  without-docker:
+    name: Java ${{matrix.java}} on ${{matrix.os}}
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macOS-latest, windows-latest ]
+        java: [ 8, 11 ]
+        distribution: [ zulu ]
+      fail-fast: false
+      max-parallel: 4
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Java ${{matrix.distribution}} ${{matrix.java}}
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{matrix.java}}
+          distribution: ${{matrix.distribution}}
+      - name: Test with Maven
+        run: ./mvnw clean verify -V -B -D"maven.artifact.threads=64" -D"org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -D"disable-toolchain" -D"java.version=${{matrix.java}}"
+      - name: Upload Unit Test Results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: Unit Test Results (Java ${{matrix.java}} on ${{matrix.os}})
+          path: "**/target/surefire-reports/**"
+  publish-test-results:
+    name: "Publish Unit Tests Results"
+    needs: [ with-docker, without-docker ]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: artifacts
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          files: "artifacts/**/*.xml"

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,8 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>3.2.0</version>
           <configuration>
+            <failOnError>false</failOnError>
+            <failOnWarnings>false</failOnWarnings>
             <quiet>true</quiet>
             <author>false</author>
           </configuration>
@@ -178,6 +180,7 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>3.0.0-M4</version>
           <configuration>
+            <failIfNoTests>false</failIfNoTests>
             <trimStackTrace>false</trimStackTrace>
           </configuration>
         </plugin>
@@ -217,6 +220,7 @@
               <exclude>NOTICE-*</exclude>
               <exclude>src/main/java/org/terracotta/org/junit/**</exclude>
               <exclude>src/test/java/org/terracotta/org/junit/**</exclude>
+              <exclude>.github/**</exclude>
             </excludes>
           </configuration>
         </plugin>
@@ -360,6 +364,26 @@
                 <configuration>
                   <keyname>Terracotta Release Engineer</keyname>
                 </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>disable-toolchain</id>
+      <activation>
+        <property>
+          <name>disable-toolchain</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-toolchains-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>none</phase>
               </execution>
             </executions>
           </plugin>

--- a/tools/src/main/java/org/terracotta/utilities/io/Files.java
+++ b/tools/src/main/java/org/terracotta/utilities/io/Files.java
@@ -511,6 +511,7 @@ public final class Files {
    * @see java.nio.file.Files#delete(Path)
    * @see java.nio.file.Files#move(Path, Path, CopyOption...)
    */
+  @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
   public static void delete(Path path, Duration renameTimeLimit, Runnable progressHelper) throws IOException {
     Objects.requireNonNull(path, "path must be non-null");
     Objects.requireNonNull(renameTimeLimit, "renameTimeLimit must be non-null");

--- a/tools/src/main/java/org/terracotta/utilities/io/FilesSupport.java
+++ b/tools/src/main/java/org/terracotta/utilities/io/FilesSupport.java
@@ -383,7 +383,7 @@ class FilesSupport {
       LOGGER.trace("Lock ended on \"{}\"", file);
     }
 
-    @SuppressFBWarnings("DLS_DEAD_LOCAL_STORE")
+    @SuppressFBWarnings({"DLS_DEAD_LOCAL_STORE", "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"})
     private void holdDirectory(Path dir) {
       LOGGER.trace("Hold on \"{}\" beginning", dir);
       try (DirectoryStream<Path> directoryStream = java.nio.file.Files.newDirectoryStream(dir)) {


### PR DESCRIPTION
- to test inside and outside containers
- to test with Java 8 and 11
- to test on lin / win and mac

Made some corrections to allow the build to run on Java 11 (project build was not compatible with Java 11)

**IMPORTANT NOTE:** Github runners do not currently support IPv6, their infrastructure is not routing IPv6. See: https://github.com/actions/virtual-environments/issues/668.

You can see the build output here: https://github.com/mathieucarbou/terracotta-utilities/runs/

![image](https://user-images.githubusercontent.com/61346/154734573-26bf132a-1eac-4552-9ae5-cb5d4862f585.png)