### PR TITLE
Avoid test failure when running CI as super-privileged user

### DIFF
--- a/test-tools/README.md
+++ b/test-tools/README.md
@@ -19,5 +19,8 @@ by `LICENSE-junit.txt` found at <https://raw.githubusercontent.com/junit-team/ju
 `1b683f4ec07bcfa40149f086d32240f805487e66`, tag `r4.13.1`) were lifted to pick up changes related to
 the resolution of CVE-2020-15250.
 
+* A local update is made to `org.terracotta.org.junit.rules.TemporaryFolderUsageTest` to avoid a test failure 
+when tests are run in a Docker container (during CI) running as root.
+
 **NOTE:** To limit changes to the files obtained from the JUnit code base to the absolute minimum, 
 the Terracotta copyright header is intentionally omitted and SpotBugs/FindBugs is intentionally suppressed.

--- a/test-tools/src/test/java/org/terracotta/org/junit/rules/TemporaryFolderUsageTest.java
+++ b/test-tools/src/test/java/org/terracotta/org/junit/rules/TemporaryFolderUsageTest.java
@@ -1,6 +1,7 @@
 package org.terracotta.org.junit.rules;
 
 import org.junit.After;
+import org.junit.AssumptionViolatedException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -102,9 +103,14 @@ public class TemporaryFolderUsageTest {
         assumeTrue("Could not make folder " + tempFolder.getRoot() + " read only.",
                 tempFolder.getRoot().setReadOnly());
 
-        thrown.expect(IOException.class);
-        thrown.expectMessage("could not create a folder with the path 'level1'");
-        tempFolder.newFolder("level1");
+//        thrown.expect(IOException.class);
+//        thrown.expectMessage("could not create a folder with the path 'level1'");
+        try {
+            tempFolder.newFolder("level1");
+            throw new AssumptionViolatedException("Folder creation successful in read-only directory; super-privileged user likely");
+        } catch (IOException e) {
+            assertThat(e.getMessage(), is("could not create a folder with the path 'level1'"));
+        }
     }
     
     @Test


### PR DESCRIPTION
This commit changes test TemporaryFolderUsageTest.newFolderWithGivenFolderThrowsIOExceptionWhenFolderCannotBeCreated
to avoid failure when the newFolder operation actually succeeds. This
can happen when the user running the test has permissions allowing the write.