### PR TITLE
Correct dependency relationships

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,15 +80,14 @@
         <version>${hamcrest.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest-library</artifactId>
-        <version>${hamcrest.version}</version>
-      </dependency>
-      <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>${junit.version}</version>
         <exclusions>
+          <exclusion>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>

--- a/port-chooser/pom.xml
+++ b/port-chooser/pom.xml
@@ -26,7 +26,6 @@
     <relativePath>..</relativePath>
   </parent>
 
-  <groupId>org.terracotta</groupId>
   <artifactId>terracotta-utilities-port-chooser</artifactId>
   <name>Terracotta Utilities Port Chooser</name>
   <description>Utility classes for TCP port management</description>
@@ -56,13 +55,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest</artifactId>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -73,6 +72,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.github.spotbugs</groupId>

--- a/test-tools/pom.xml
+++ b/test-tools/pom.xml
@@ -26,7 +26,6 @@
     <relativePath>..</relativePath>
   </parent>
 
-  <groupId>org.terracotta</groupId>
   <artifactId>terracotta-utilities-test-tools</artifactId>
   <name>Terracotta Utilities Test Tools</name>
   <description>Utility classes/methods for use in testing</description>
@@ -52,11 +51,6 @@
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -26,7 +26,6 @@
     <relativePath>..</relativePath>
   </parent>
 
-  <groupId>org.terracotta</groupId>
   <artifactId>terracotta-utilities-tools</artifactId>
   <name>Terracotta Utilities Tools</name>
   <description>Utility classes/methods for common Java tasks</description>
@@ -57,6 +56,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
THis commit makes several dependency corrections:

* changes the scope of logback-classic from compile to test in the
terracotta-utilities-tools and terracotta-utilities-port-chooser modules
* Adjusted the Hamcrest vs JUnit dependencies
