### PR TITLE
Random test failure found

### DIFF
--- a/test-tools/src/main/java/org/terracotta/org/junit/rules/ExternalResource.java
+++ b/test-tools/src/main/java/org/terracotta/org/junit/rules/ExternalResource.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Terracotta, Inc., a Software AG company.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.org.junit.rules;
+
+import org.junit.runner.Description;
+import org.junit.runners.model.MultipleFailureException;
+import org.junit.runners.model.Statement;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Equivalent of {@link org.junit.rules.ExternalResource}, but correctly handling failure in after method.
+ */
+public class ExternalResource extends org.junit.rules.ExternalResource {
+  @Override
+  public Statement apply(Statement base, Description description) {
+    return new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        before();
+        List<Throwable> errors = new ArrayList<>(2);
+        try {
+          base.evaluate();
+        } catch (Throwable t) {
+          errors.add(t);
+        } finally {
+          try {
+            after();
+          } catch (Throwable t) {
+            errors.add(t);
+          }
+        }
+        MultipleFailureException.assertEmpty(errors);
+      }
+    };
+  }
+}


### PR DESCRIPTION
```
Error:  Tests run: 2, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.053 s <<< FAILURE! - in org.terracotta.utilities.test.DiagnosticsTest
Error:  org.terracotta.utilities.test.DiagnosticsTest.testDumpThreads  Time elapsed: 0.042 s  <<< FAILURE!
java.lang.AssertionError: 

Expected: iterable containing [(a string starting with "\"Blocked Thread\"" and a string containing "WAITING on"), (a string starting with "\"Terminated Thread\"" and a string containing "TERMINATED"), (a string starting with "\"main\"" and a string containing "RUNNABLE")] in relative order
     but: (a string starting with "\"Blocked Thread\"" and a string containing "WAITING on") was not found
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.junit.Assert.assertThat(Assert.java:956)
	at org.junit.Assert.assertThat(Assert.java:923)
	at org.terracotta.utilities.test.DiagnosticsTest.testDumpThreads(DiagnosticsTest.java:69)
```