### PR TITLE
Allow test result publication for PR build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,11 +108,27 @@ jobs:
           path: |
             **/target/surefire-reports/**
             **/target/rat.txt
+  event_file:
+    name: "Event File"
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - name: Upload
+        uses: actions/upload-artifact@v2
+        with:
+          name: Event File
+          path: ${{ github.event_path }}
+  # this job will publish test results when the build is executed:
+  # - either within someone's fork, for a fork's branch
+  # - either for master build
+  # Actions run on a pull_request event for a fork repository cannot
+  # do anything useful like creating check runs or pull request comments
+  # as part of the CI script
   publish-test-results:
     name: "Publish Tests Results"
     needs: [ with-container-root, with-container-user, without-container ]
     runs-on: ubuntu-latest
-    if: always()
+    if: ${{ github.event_name != 'pull_request' }}
     steps:
       - name: Download Artifacts
         uses: actions/download-artifact@v2

--- a/.github/workflows/publish-test-results.yaml
+++ b/.github/workflows/publish-test-results.yaml
@@ -1,0 +1,32 @@
+name: Publish Tests Results
+on:
+  workflow_run:
+    workflows: [ "CI" ]
+    types:
+      - completed
+jobs:
+  publish-test-results:
+    name: Publish Tests Results
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion != 'skipped' }}
+    steps:
+      - name: Download and Extract Artifacts
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+          mkdir -p artifacts && cd artifacts          
+          artifacts_url=${{ github.event.workflow_run.artifacts_url }}
+          gh api "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
+          do
+            IFS=$'\t' read name url <<< "$artifact"
+            gh api $url > "$name.zip"
+            unzip -d "$name" "$name.zip"
+          done
+      - name: Publish Tests Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        if: hashFiles('artifacts/Event File/event.json') != ''
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: artifacts/Event File/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          files: "**/target/surefire-reports/**/*.xml"


### PR DESCRIPTION
See for explanations: https://github.com/EnricoMi/publish-unit-test-result-action/blob/v1.20/README.md#support-fork-repositories-and-dependabot-branches

Fixes warning: *This action is running on a pull_request event for a fork repository. It cannot do anything useful like creating check runs or pull request comments. To run the action on fork repository pull requests, see https://github.com/EnricoMi/publish-unit-test-result-action/blob/v1.20/README.md#support-fork-repositories-and-dependabot-branches*