### PR TITLE
Allow test result publication for PR build.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,16 @@ on:
       - master
       - ga # required at the moment until this PR is merged, to verify it works in my fork. Can be removed after once GA build integration is finished.
 jobs:
+  event_file:
+    name: "Publish Github Event Information"
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - name: Upload
+        uses: actions/upload-artifact@v2
+        with:
+          name: Event File
+          path: ${{ github.event_path }}
   with-container-root:
     # uncomment to disable this job
     #if: ${{ false }}
@@ -108,24 +118,15 @@ jobs:
           path: |
             **/target/surefire-reports/**
             **/target/rat.txt
-  event_file:
-    name: "Event File"
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' }}
-    steps:
-      - name: Upload
-        uses: actions/upload-artifact@v2
-        with:
-          name: Event File
-          path: ${{ github.event_path }}
   # this job will publish test results when the build is executed:
   # - either within someone's fork, for a fork's branch
   # - either for master build
   # Actions run on a pull_request event for a fork repository cannot
   # do anything useful like creating check runs or pull request comments
   # as part of the CI script
+  # More info: https://github.com/EnricoMi/publish-unit-test-result-action/blob/v1.20/README.md#support-fork-repositories-and-dependabot-branches
   publish-test-results:
-    name: "Publish Tests Results"
+    name: "Publish Tests Results (non-PR build)"
     needs: [ with-container-root, with-container-user, without-container ]
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'pull_request' }}
@@ -137,4 +138,7 @@ jobs:
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1
         with:
+          report_individual_runs: true
+          comment_mode: update last
+          check_name: Tests Results
           files: "**/target/surefire-reports/**/*.xml"

--- a/.github/workflows/publish-pr-test-results.yaml
+++ b/.github/workflows/publish-pr-test-results.yaml
@@ -1,12 +1,15 @@
-name: Publish Tests Results
+# this workflow is publishing in the upstream repository test results
+# obtained from PR build (from fork's branches)
+# More info: https://github.com/EnricoMi/publish-unit-test-result-action/blob/v1.20/README.md#support-fork-repositories-and-dependabot-branches
+name: Publish Tests Results (PR builds)
 on:
   workflow_run:
     workflows: [ "CI" ]
     types:
       - completed
 jobs:
-  publish-test-results:
-    name: Publish Tests Results
+  publish-pr-test-results:
+    name: Publish Tests Results (PR builds)
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion != 'skipped' }}
     steps:
@@ -22,10 +25,13 @@ jobs:
             gh api $url > "$name.zip"
             unzip -d "$name" "$name.zip"
           done
-      - name: Publish Tests Results
+      - name: Publish Tests Results (PR builds)
         uses: EnricoMi/publish-unit-test-result-action@v1
         if: hashFiles('artifacts/Event File/event.json') != ''
         with:
+          report_individual_runs: true
+          comment_mode: update last
+          check_name: Tests Results
           commit: ${{ github.event.workflow_run.head_sha }}
           event_file: artifacts/Event File/event.json
           event_name: ${{ github.event.workflow_run.event }}


### PR DESCRIPTION
See for explanations: https://github.com/EnricoMi/publish-unit-test-result-action/blob/v1.20/README.md#support-fork-repositories-and-dependabot-branches
Fixes warning: *This action is running on a pull_request event for a fork repository. It cannot do anything useful like creating check runs or pull request comments. To run the action on fork repository pull requests, see https://github.com/EnricoMi/publish-unit-test-result-action/blob/v1.20/README.md#support-fork-repositories-and-dependabot-branches*