### PR TITLE
Add support for supplemental threads to ConsoleAppenderCapture

### DIFF
--- a/test-tools/src/main/java/org/terracotta/utilities/test/logging/ConsoleAppenderCapture.java
+++ b/test-tools/src/main/java/org/terracotta/utilities/test/logging/ConsoleAppenderCapture.java
@@ -27,12 +27,14 @@ import ch.qos.logback.core.spi.FilterReply;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentSkipListSet;
 
 import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
@@ -43,6 +45,20 @@ import static java.util.stream.Collectors.toMap;
 /**
  * Captures output associated with the current thread logged to each active {@link ConsoleAppender}
  * instance in the current logging environment.
+ *
+ * <h3>Implementation Details</h3>
+ * This class relies on the {@link MDC} and an internally-generated {@code MDC key} to determine which
+ * logging events to capture.  Due to changes in {@code MDC} inheritance (see
+ * <a href="https://jira.qos.ch/browse/LOGBACK-422">LOGBACK-422 Automatic MDC inheritance with thread pools cases false data printed in the log</a>
+ * and
+ * <a href="https://jira.qos.ch/browse/LOGBACK-624">LOGBACK-624 MDC Adapter with configurable InheritableThreadLocal</a>),
+ * only messages issued from the thread creating the {@code ConsoleAppenderCapture} instance is covered.
+ * To extend coverage to other threads, use the {@link #addSupplementalThread(Thread)} or a method relying
+ * on {@link MDC#getCopyOfContextMap()} and {@link MDC#setContextMap(Map)} as described in
+ * <a href="https://stackoverflow.com/a/43442258/1814086">How to get back MDC "inheritance" with modern logback?</a>.
+ *
+ * @see <a href="https://logback.qos.ch/manual/mdc.html">Logback Documentation : Mapped Diagnostic Context</a>
+ * @see MDC
  */
 public class ConsoleAppenderCapture implements AutoCloseable {
   private static final String MDC_KEY_ROOT = ConsoleAppenderCapture.class.getSimpleName() + ".testId";
@@ -51,6 +67,11 @@ public class ConsoleAppenderCapture implements AutoCloseable {
   private final String mdcKey = MDC_KEY_ROOT + '.' + UUID.randomUUID();
   private final Runnable removeAppenders;
   private final Map<String, ListAppender<ILoggingEvent>> appenderMap = new HashMap<>();
+  /**
+   * Holds the names of {@code Thread} instances to capture in addition to those carrying
+   * the {@code MDC} key.
+   */
+  private final Set<String> supplementalThreads = new ConcurrentSkipListSet<>();
 
   /**
    * Creates a new {@code ConsoleAppenderCapture} instance for {@code testId}.
@@ -144,6 +165,8 @@ public class ConsoleAppenderCapture implements AutoCloseable {
               public FilterReply decide(ILoggingEvent iLoggingEvent) {
                 if (iLoggingEvent.getMDCPropertyMap().getOrDefault(mdcKey, "").equals(ConsoleAppenderCapture.this.testId)) {
                   return FilterReply.ACCEPT;
+                } else if (supplementalThreads.contains(iLoggingEvent.getThreadName())) {
+                  return FilterReply.ACCEPT;
                 } else {
                   return FilterReply.DENY;      // Filter only applies to 'this' Appender -- can stop processing here
                 }
@@ -169,7 +192,29 @@ public class ConsoleAppenderCapture implements AutoCloseable {
   }
 
   /**
+   * Adds the <i>name</i> of the specified {@link Thread} as a supplemental capture thread.
+   * <p>
+   * Only the thread name is tracked; if a non-unique thread name is provided, events from
+   * all like-named threads are captured.
+   * @param thread the {@code Thread} for which events are captured
+   */
+  public void addSupplementalThread(Thread thread) {
+    this.supplementalThreads.add(requireNonNull(thread, "thread").getName());
+  }
+
+  /**
+   * Removes the <i>name</i> of the specified {@link Thread} as a supplemental capture thread.
+   * @param thread the {@code Thread} for which events were captured
+   * @see #addSupplementalThread(Thread)
+   */
+  public void removeSupplementalThread(Thread thread) {
+    this.supplementalThreads.remove(requireNonNull(thread, "thread").getName());
+  }
+
+  /**
    * Gets a reference to the {@code List}s into which log entries are captured.
+   * <h3>Note</h3>
+   * The returned {@code List} instances are <b>not</b> synchronized against concurrent access.
    *
    * @return the map of logging target to log entry list reference; the key of the
    *      map is the {@link ConsoleAppender#getTarget()} value for which
@@ -182,28 +227,87 @@ public class ConsoleAppenderCapture implements AutoCloseable {
   }
 
   /**
+   * Gets the "raw" events logged to the specified target.
+   * <p>
+   * This method is internally synchronized against the {@code Appender} used to capture the logging events.
+   *
+   * @param target the target for which log messages are to be returned
+   * @return the list of events logged to {@code target}l may be empty
+   */
+  @SuppressWarnings("SynchronizationOnLocalVariableOrMethodParameter")
+  public List<ILoggingEvent> getEvents(Target target) {
+    ListAppender<ILoggingEvent> appender = appenderMap.get(target.targetName());
+    if (appender == null) {
+      return emptyList();
+    } else {
+      // ListAppender.doAppend is synchronized against ListAppender instance
+      synchronized (appender) {
+        return new ArrayList<>(appender.list);
+      }
+    }
+  }
+
+  /**
    * Gets the events, in formatted string form, logged to the specified target.
+   * <p>
+   * This method is internally synchronized against the {@code Appender} used to capture the logging events.
+   *
    * @param target the target for which log messages are to be returned
    * @return the list of messages logged to {@code target}; may be empty
    */
+  @SuppressWarnings("SynchronizationOnLocalVariableOrMethodParameter")
   public List<String> getMessages(Target target) {
     requireNonNull(target, "target");
-    return Optional.ofNullable(appenderMap.get(target.targetName()))
-        .map(a -> a.list).orElse(emptyList())
-        .stream().map(ILoggingEvent::getFormattedMessage).collect(toList());
+    ListAppender<ILoggingEvent> appender = appenderMap.get(target.targetName());
+    if (appender == null) {
+      return emptyList();
+    } else {
+      // ListAppender.doAppend is synchronized against ListAppender instance
+      synchronized (appender) {
+        return appender.list.stream().map(ILoggingEvent::getFormattedMessage).collect(toList());
+      }
+    }
   }
 
   /**
    * Gets the events, in formatted string form, as a single string with events
    * separated by {@link System#lineSeparator()}.
+   * <p>
+   * This method is internally synchronized against the {@code Appender} used to capture the logging events.
+   *
    * @param target the target for which log messages are to be returned
    * @return a string containing all messages logged to {@code target}; may be empty
    */
+  @SuppressWarnings("SynchronizationOnLocalVariableOrMethodParameter")
   public String getMessagesAsString(Target target) {
     requireNonNull(target, "target");
-    return Optional.ofNullable(appenderMap.get(target.targetName()))
-        .map(a -> a.list).orElse(emptyList())
-        .stream().map(ILoggingEvent::getFormattedMessage).collect(joining(System.lineSeparator()));
+    ListAppender<ILoggingEvent> appender = appenderMap.get(target.targetName());
+    if (appender == null) {
+      return "";
+    } else {
+      // ListAppender.doAppend is synchronized against ListAppender instance
+      synchronized (appender) {
+        return appender.list.stream().map(ILoggingEvent::getFormattedMessage).collect(joining(System.lineSeparator()));
+      }
+    }
+  }
+
+  /**
+   * Clears the captured logging events for the specified {@code Target}.
+   * <p>
+   * This method is internally synchronized against the {@code Appender} used to capture the logging events.
+   *
+   * @param target the target for which log messages are to be cleared
+   */
+  @SuppressWarnings("SynchronizationOnLocalVariableOrMethodParameter")
+  public void clear(Target target) {
+    requireNonNull(target, "target");
+    ListAppender<ILoggingEvent> appender = appenderMap.get(target.targetName());
+    if (appender != null) {
+      synchronized (appender) {
+        appender.list.clear();
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
This commit adds:

* support for identifying log capture threads in addition to the creating thread
* getting a list of the captured logging events
* clearing the captured log events

This update is added to enable use when the `ConsoleAppender` output to be captured is generated by a thread for which direct capture is not possible.  Since multiple threads are involved (at least the observer and the generator threads), synchronization is added for access to the captured output.  (`ListAppender` uses an unsynchronized `ArrayList`; however, `ListAppender` is based on `AppenderBase` which synchronizes on _itself_ when appending so access to the captured events is now synchronizing on the `ListAppender`.)

This is a _daggy_ commit stream.