### PR TITLE
Add support for Files.createFile

### DIFF
--- a/tools/src/test/java/org/terracotta/utilities/concurrent/InterprocessCyclicBarrier.java
+++ b/tools/src/test/java/org/terracotta/utilities/concurrent/InterprocessCyclicBarrier.java
@@ -1,0 +1,992 @@
+/*
+ * Copyright 2022 Terracotta, Inc., a Software AG company.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.utilities.concurrent;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Implements an inter-process coordination barrier similar to {@link java.util.concurrent.CyclicBarrier CyclicBarrier}.
+ * <p>
+ * Unlike, {@code CyclicBarrier}, {@code InterprocessCyclicBarrier} requires each participant <i>register</i>
+ * with the barrier after local instantiation.  Registration generates a {@link Participant} instance that
+ * is then used to manage barrier coordination.
+ *
+ * <h3>Notes</h3>
+ * <ul>
+ *   <li>
+ *     This implementation is <b>not</b> suitable for critical use -- it is currently intended for test
+ *     use cases and lacks the robustness necessary for critical use.
+ *   </li>
+ *   <li>
+ *     More than one instance of {@code InterprocessCyclicBarrier} over the same file
+ *     <b>cannot</b> be used in a single JVM.  The file locking used is not effective in preventing
+ *     interaction among multiple threads in a JVM -- at best,
+ *     {@link java.nio.channels.OverlappingFileLockException OverlappingFileLockException} is
+ *     thrown and may result in thread/process hangs.
+ *   </li>
+ *   <li>
+ *     If a participant fails to call {@link #register()} <i>and</i> does not close its
+ *     {@code InterprocessCyclicBarrier} instance, other participants in the barrier
+ *     will wait forever in an {@code await} call.  The current implementation does not
+ *     provide a timed wait option.
+ *   </li>
+ *   <li>
+ *     This implementation does not provide a {@code reset()} method.
+ *   </li>
+ * </ul>
+ *
+ * @see java.util.concurrent.CyclicBarrier
+ */
+public class InterprocessCyclicBarrier implements AutoCloseable {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(InterprocessCyclicBarrier.class);
+
+  private final AtomicBoolean closed = new AtomicBoolean(false);
+  private final AtomicBoolean broken = new AtomicBoolean(false);
+  private final Set<Participant> localParticipants = new CopyOnWriteArraySet<>();
+
+  private final int participantCount;
+  private final int fullMask;
+  private final Path syncFile;
+  private final BarrierAccessor barrierAccessor;
+
+  /**
+   * Create a {@code InterprocessCyclicBarrier} for the indicated number of participants using the
+   * file at {@code syncFile} for inter-process communication.
+   * <p>
+   * Every instantiation using the same {@code syncFile} must agree on the number of participants.  A failure
+   * within this constructor results in a broken barrier.
+   * @param participantCount the number of participants in the barrier
+   * @param syncFile the file to use for inter-process synchronization
+   * @throws IOException
+   *        if an error is raise opening, reading, or writing to {@code syncFile}
+   * @throws IllegalStateException
+   *        if {@code syncFile} is already initialized with a different participant count
+   */
+  public InterprocessCyclicBarrier(int participantCount, Path syncFile) throws IOException {
+    if (participantCount <= 1 || participantCount > Integer.SIZE) {
+      throw new IllegalArgumentException("participantCount must be greater than 1 and not more than " + Integer.SIZE);
+    }
+    LOGGER.trace("Instantiating {}({}, {})", this.getClass().getSimpleName(), participantCount, syncFile);
+
+    this.participantCount = participantCount;
+    this.fullMask = (1 << participantCount) - 1;
+    this.syncFile = requireNonNull(syncFile, "syncFile");
+
+    this.barrierAccessor = new BarrierAccessor(this.syncFile);
+    try {
+      barrierAccessor.underLock((accessor, record) -> {
+        if (record.participantCount() == 0) {
+          /*
+           * If this is the first access, initialize the sync data.
+           */
+          accessor
+              .participantCount(participantCount)
+              .generation(0)
+              .activeMask(0)              // Initialized with no participants active
+              .pendingMask(fullMask);     // But all potential participants pending
+        } else {
+          /*
+           * Otherwise, ensure the provided participant count matches the existing one.
+           */
+          int discoveredCount = record.participantCount();
+          if (discoveredCount != this.participantCount) {
+            throw new IllegalStateException(
+                String.format("Participant count mismatch: instance=%d, sync file (%s)=%d",
+                    this.participantCount, syncFile, discoveredCount));
+          }
+        }
+        return null;
+      });
+    } catch (RuntimeException | IOException e) {
+      breakBarrier().ifPresent(e::addSuppressed);
+      throw e;
+    }
+  }
+
+  /**
+   * Registers a new participant in this {@code InterprocessCyclicBarrier}.
+   * @return the participant identifier
+   * @throws IOException if an error is raised while writing to the sync file
+   * @throws InterruptedException if the calling thread is interrupted; the barrier state becomes <i>broken</i>
+   * @throws BrokenBarrierException if the barrier is broken by another participant
+   * @throws IllegalStateException if all barrier participants have already registered
+   */
+  public synchronized Participant register() throws IOException, BrokenBarrierException, InterruptedException {
+    checkClosed();
+    if (Thread.interrupted()) {
+      InterruptedException interruptedException = new InterruptedException();
+      breakBarrier().ifPresent(interruptedException::addSuppressed);
+      throw interruptedException;
+    }
+    checkBroken();
+
+    int participantMask;
+    try {
+      participantMask = barrierAccessor.underLock((accessor, record) -> {
+
+        /*
+         * If the barrier is already broken ...
+         */
+        if (record.isBroken()) {
+          broken.set(true);
+          throw new Broken();
+        }
+
+        if (record.participantCount() != participantCount) {
+          barrierAccessor.setBroken();
+          broken.set(true);
+          throw new IllegalStateException(
+              String.format("Participant count mismatch: instance=%d, sync file (%s)=%d",
+                  record.participantCount(), syncFile, participantCount));
+        }
+
+        int activeMask = record.activeMask();
+        if (Integer.bitCount(activeMask) >= participantCount) {
+          throw new IllegalStateException(
+              String.format("All expected participants (%d) are registered with sync file (%s);"
+                  + " no further registrations are permitted", participantCount, syncFile));
+        }
+
+        // Assign the participant the rightmost zero bit
+        int assignedParticipantMask = ~activeMask & (activeMask + 1);
+
+        accessor.activeMask(activeMask | assignedParticipantMask);
+        accessor.pendingMask(record.pendingMask() | assignedParticipantMask);
+
+        return assignedParticipantMask;
+      });
+    } catch (Broken e) {
+      BrokenBarrierException exception = new BrokenBarrierException();
+      exception.initCause(e);
+      throw exception;
+    } catch (IOException e) {
+      throw new IOException("Failed to register participant with sync file " + syncFile, e);
+    }
+
+    Participant participant = new Participant(participantMask);
+    localParticipants.add(participant);
+    LOGGER.trace("Barrier participant registered {}", participant);
+    return participant;
+  }
+
+  /**
+   * Waits until all participants have called {@code await()}.
+   * @see Participant#await(String)
+   */
+  private int await(Participant participant, String loggingContext)
+      throws IOException, InterruptedException, BrokenBarrierException {
+    requireNonNull(participant, "participant");
+    checkClosed();
+    if (Thread.interrupted()) {
+      InterruptedException interruptedException = new InterruptedException();
+      breakBarrier().ifPresent(interruptedException::addSuppressed);
+      throw interruptedException;
+    }
+    checkBroken();
+    LOGGER.trace("Entering await({}) for {}", loggingContext, participant);
+
+    int participantMask = participant.participantMask;
+    int[] arrivalOrder = new int[1];
+    if (localParticipants.contains(participant)) {
+
+      /*
+       * Indicate, through the sync file, that the participant has reached await and is
+       * no longer pending.  Remember the current generation -- the last arriving
+       * participant will advance it so the current generation is complete if it's different.
+       */
+      int currentGeneration;
+      synchronized (this) {
+        try {
+          currentGeneration = barrierAccessor.underLock((accessor, record) -> {
+            int generation = record.generation();
+            if (record.isBroken()) {
+              LOGGER.trace("Barrier ({}) is BROKEN for {}", loggingContext, syncFile);
+              broken.set(true);
+              throw new Broken();
+            } else if (record.isTerminating()) {
+              LOGGER.trace("Barrier ({}) was TERMINATING, now BROKEN for {}", loggingContext, syncFile);
+              barrierAccessor.setBroken();
+              broken.set(true);
+              throw new Broken();
+            }
+
+            int pendingMask = record.pendingMask();
+            if ((pendingMask & participantMask) != 0) {
+              int remaining = pendingMask & ~participantMask;
+              arrivalOrder[0] = Integer.bitCount(remaining);
+              if (arrivalOrder[0] == 0) {
+                accessor.pendingMask(fullMask);               // Prepare pending for next cycle
+                accessor.generation(generation + 1);          // Last pending; advance generation
+              } else {
+                accessor.pendingMask(remaining);
+              }
+              LOGGER.trace("Barrier ({}) arrival: arrivalOrder={}, generation={}, remaining=0x{} {}",
+                  loggingContext, arrivalOrder[0], generation, Integer.toHexString(remaining), participant);
+            } else {
+              // The participant wasn't recorded as being active!
+              throw new IllegalStateException("Participant " + Integer.lowestOneBit(participantMask)
+                  + " is not pending in sync file " + syncFile);
+            }
+
+            return generation;
+          });
+        } catch (Broken e) {
+          BrokenBarrierException exception = new BrokenBarrierException();
+          exception.initCause(e);
+          throw exception;
+        } catch (IOException e) {
+          IOException fault = new IOException("Failed to record arrival of participant "
+              + Integer.lowestOneBit(participantMask) + " in sync file " + syncFile);
+          breakBarrier().ifPresent(fault::addSuppressed);
+          throw fault;
+        }
+      }
+
+      LOGGER.trace("Barrier ({}) wait: arrivalOrder={}, generation={} {}",
+          loggingContext, arrivalOrder[0], currentGeneration, participant);
+
+      /*
+       * If we're the last to arrive, our wait is done.  Otherwise, we need to poll until the
+       * generation changes, the barrier is BROKEN, or the barrier is TERMINATING.  In the last
+       * case, we move the barrier to BROKEN.
+       */
+      if (arrivalOrder[0] == 0) {
+        LOGGER.trace("Barrier ({}) wait ended: arrivalOrder=0 oldGeneration={}, newGeneration=? {}",
+            loggingContext, currentGeneration, participant);
+        return arrivalOrder[0];
+      } else {
+        while (true) {
+          BarrierRecord record;
+          synchronized (this) {
+            record = barrierAccessor.getUnderLock();
+          }
+          int generation = record.generation();
+          if (record.isBroken()) {
+            LOGGER.trace("Barrier ({}) is BROKEN for {}", loggingContext, syncFile);
+            broken.set(true);
+            throw new BrokenBarrierException();
+          } else if (record.isTerminating() && generation == currentGeneration) {
+            /*
+             * Some participant has de-registered _before_ calling the matching await -- barrier is BROKEN
+             */
+            LOGGER.trace("Barrier ({}) was TERMINATING, now BROKEN; activeMask=0x{}, pendingMask=0x{}, generation={} {}",
+                loggingContext, Integer.toHexString(record.activeMask()), Integer.toHexString(record.pendingMask()),
+                generation, syncFile);
+            BrokenBarrierException brokenBarrierException = new BrokenBarrierException();
+            breakBarrier().ifPresent(brokenBarrierException::addSuppressed);
+            throw brokenBarrierException;
+          } else if (generation != currentGeneration) {
+            /*
+             * If generation has advanced, all participants have arrived; some may have already
+             * de-registered, so the barrier may already be TERMINATING.
+             */
+            LOGGER.trace("Barrier ({}) wait ended: arrivalOrder={}, oldGeneration={}, newGeneration={}, isTerminating={} {}",
+                loggingContext, arrivalOrder[0], currentGeneration, generation, record.isTerminating(), participant);
+            return arrivalOrder[0];
+          } else {
+            TimeUnit.MILLISECONDS.sleep(100L);
+          }
+        }
+      }
+
+    } else {
+      throw new IllegalStateException("Participant " + Integer.lowestOneBit(participantMask) + " is not registered");
+    }
+  }
+
+  /**
+   * De-registers a participant from this {@code InterprocessCyclicBarrier}.  This barrier
+   * is marked as {@code TERMINATING}.
+   * <p>
+   * A failure to de-register a participant does not cause a broken barrier.
+   * @param participant the identifier of the participant to de-register
+   * @throws IOException if an error is raised while reading from or  writing to the sync file
+   * @see Participant#deregister()
+   */
+  synchronized void deregister(Participant participant) throws IOException {
+    requireNonNull(participant, "participant");
+    if (closed.get()) {
+      return;
+    }
+
+    boolean interrupted = Thread.interrupted();
+    try {
+      deregisterInternal(participant);
+    } finally {
+      if (interrupted) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
+  private void deregisterInternal(Participant participant) throws IOException {
+    if (localParticipants.contains(participant)) {
+      LOGGER.trace("De-registering {}", participant);
+
+      int participantMask = participant.participantMask;
+      try {
+        barrierAccessor.underLock((accessor, record) -> {
+
+          int activeMask = record.activeMask();
+          if ((activeMask & participantMask) != 0) {
+            // Indicate the barrier is terminating if not already TERMINATING or BROKEN
+            if (!record.isBroken() && !record.isTerminating()) {
+              accessor.setTerminating();
+              LOGGER.trace("Barrier marked terminating by {}", participant);
+            }
+
+            // Remove the participant
+            accessor.pendingMask(record.pendingMask() & ~participantMask);
+            accessor.activeMask(activeMask & ~participantMask);
+            LOGGER.trace("Barrier participant de-registered {}", participant);
+          }
+
+          return null;
+        });
+      } catch (IOException e) {
+        throw new IOException("Failed to de-register participant "
+            + Integer.lowestOneBit(participantMask) + " from sync file " + syncFile, e);
+      } finally {
+        participant.registered.set(false);
+        localParticipants.remove(participant);
+        LOGGER.trace("Barrier participant removed {}", participant);
+      }
+    }
+  }
+
+  /**
+   * Indicates if this {@code InterprocessCyclicBarrier} is in a broken state.  If this barrier
+   * is closed, the last known broken state is returned.
+   * <p>
+   * This method will attempt to access the sync file if this barrier is not known to be
+   * in a broken state.
+   * @return {@code true} if this barrier is broken; {@code false} otherwise
+   * @throws UncheckedIOException if an error is raised while reading the sync file
+   */
+  public boolean isBroken() {
+    if (closed.get()) {
+      return broken.get();
+    } else if (broken.get()) {
+      return true;
+    } else {
+      boolean interrupted = Thread.interrupted();
+      BarrierRecord record;
+      try {
+        record = barrierAccessor.getUnderLock();
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      } finally {
+        if (interrupted) {
+          Thread.currentThread().interrupt();
+        }
+      }
+      boolean broken = record.isBroken();
+      if (broken) {
+        this.broken.compareAndSet(false, true);
+      }
+      return broken;
+    }
+  }
+
+  /**
+   * Change the sync file state to indicate the barrier is broken.  After recording the broken state,
+   * the sync file is closed.  This method may fail without throwing an exception.
+   *
+   * @return the exception, if any, raised while marking broken barrier state in the sync file
+   */
+  private synchronized Optional<Exception> breakBarrier() {
+    LOGGER.trace("Breaking barrier for {}", syncFile);
+    boolean interrupted = Thread.interrupted();
+    BarrierAccessor temp = this.barrierAccessor;
+    try (BarrierAccessor localAccessor = (temp.isClosed() ? new BarrierAccessor(syncFile) : temp)) {
+      localAccessor.underLock((accessor, record) -> {
+        accessor.setBroken();
+        return null;
+      });
+      return Optional.empty();
+    } catch (Exception e) {
+      LOGGER.error("Failed to mark sync file {} as broken", syncFile, e);
+      return Optional.of(e);
+    } finally {
+      broken.set(true);
+      if (interrupted) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
+  /**
+   * De-registers local participants, marks this barrier as {@code TERMINATING}, and closes the sync file.
+   * @throws IOException if there was an error raised while de-registering the participants or closing the sync file
+   */
+  @Override
+  public synchronized void close() throws IOException {
+    if (closed.compareAndSet(false, true)) {
+      LOGGER.trace("Closing barrier for {}", syncFile);
+      boolean interrupted = Thread.interrupted();
+      try {
+        List<Exception> errors = new ArrayList<>();
+
+        ArrayList<Participant> participants = new ArrayList<>(localParticipants);
+        if (barrierAccessor.isClosed()) {
+          /*
+           * If barrierAccessor is already closed, we can't formally de-register our
+           * participants.  We can, however, remove any remaining participant ids
+           * and mark them no longer registered.
+           */
+          participants.forEach(id -> {
+            localParticipants.remove(id);
+            id.registered.set(false);
+          });
+
+        } else {
+          /*
+           * The barrierAccessor is not closed -- formally deregister the participants
+           * then close the barrierAccessor.
+           */
+          for (Participant localParticipant : participants) {
+            try {
+              deregisterInternal(localParticipant);
+            } catch (IOException e) {
+              errors.add(e);
+            }
+          }
+
+          // No participants de-registered -- mark the barrier TERMINATING
+          if (participants.isEmpty()) {
+            try {
+              barrierAccessor.underLock((accessor, record) -> {
+                if (!record.isTerminating() && !record.isBroken()) {
+                  accessor.setTerminating();
+                }
+                return null;
+              });
+            } catch (IOException e) {
+              errors.add(e);
+            }
+          }
+
+          try {
+            barrierAccessor.close();
+          } catch (IOException e) {
+            errors.forEach(e::addSuppressed);
+            throw  e;
+          }
+        }
+
+        if (!errors.isEmpty()) {
+          IOException ioException = new IOException("Failed to de-register participants from " + syncFile);
+          errors.forEach(ioException::addSuppressed);
+          throw ioException;
+        }
+      } finally {
+        if (interrupted) {
+          Thread.currentThread().interrupt();
+        }
+      }
+    }
+  }
+
+  private void checkBroken() throws BrokenBarrierException {
+    if (broken.get()) {
+      throw new BrokenBarrierException("Barrier using sync file " + syncFile + " is broken");
+    }
+  }
+
+  private void checkClosed() throws IllegalStateException {
+    if (closed.get()) {
+      throw new IllegalStateException("Barrier using sync file " + syncFile +" is closed");
+    }
+  }
+
+  /**
+   * Package-private method to return the current barrier sync file content.
+   * @return a new {@code BarrierRecord} holding the current state of the barrier
+   */
+  synchronized BarrierRecord get() throws IOException {
+    boolean interrupted = Thread.interrupted();
+    try (BarrierAccessor localAccessor = new BarrierAccessor(syncFile)) {
+      return localAccessor.getUnderLock();
+    } finally {
+      if (interrupted) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
+  /**
+   * Issue a {@code buffer.force()} and manage the exception fallout.
+   * <p>
+   * The implementation of {@link MappedByteBuffer#force()} can throw an {@link IOException} but lacks the
+   * declaration for the checked exception.
+   * JDK bug <a href="https://bugs.openjdk.java.net/browse/JDK-6539707">JDK-6539707 (fc) MappedByteBuffer.force() method throws an IOException in a very simple test</a>
+   * tracks this aberrant behavior and indicates the problem is "fixed" in JDK 17 -- ultimately by wrapping the
+   * {@code IOException} in an {@link UncheckedIOException}.
+   * @param buffer the {@code MappedByteBuffer} on which the {@code force} method is called
+   * @return {@code buffer}
+   * @throws IOException if {@code force} fails to sync
+   */
+  @SuppressWarnings("UnusedReturnValue")
+  private static MappedByteBuffer force(MappedByteBuffer buffer) throws IOException {
+    return ioOp(buffer::force);
+  }
+
+  /**
+   * Issue a {@code buffer.load()} and manage the exception fallout.
+   * <p>
+   * Unlike {@link MappedByteBuffer#force()}, the fact that {@code MappedByteBuffer.load()} can throw an undeclared
+   * {@code IOException} is not (yet) recognized but the *NIX implementation can.
+   * @param buffer the {@code MappedByteBuffer} on which the {@code load} method is called
+   * @return {@code buffer}
+   * @throws IOException if {@code load} fails
+   */
+  @SuppressWarnings("UnusedReturnValue")
+  private static MappedByteBuffer load(MappedByteBuffer buffer) throws IOException {
+    return ioOp(buffer::load);
+  }
+
+  private static MappedByteBuffer ioOp(Callable<MappedByteBuffer> ioOp) throws IOException {
+    try {
+      return ioOp.call();
+    } catch (Exception e) {
+      if (e instanceof IOException) {                   // Undeclared, expected before JDK 17
+        throw (IOException)e;
+      } else if (e instanceof UncheckedIOException) {   // Expected with JDK 17 and beyond
+        throw ((UncheckedIOException)e).getCause();
+      } else if (e instanceof RuntimeException) {       // Not expected
+        throw (RuntimeException)e;
+      } else {                                          // Not expected
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  /**
+   * Identifies a registered {@code InterprocessCyclicBarrier} participant.  An instance of
+   * this class is used to manage barrier coordination for the participant.
+   */
+  public final class Participant implements AutoCloseable {
+    private final int participantMask;
+    private final AtomicBoolean registered = new AtomicBoolean(true);
+
+    private Participant(int participantMask) {
+      this.participantMask = participantMask;
+    }
+
+    /**
+     * Indicates if this {@code Participant} is currently registered.
+     * @return {@code true} if the participant has not been de-registered
+     */
+    public boolean isRegistered() {
+      return registered.get();
+    }
+
+    /**
+     * Package-private method to obtain the participant mask.
+     * @return the participant mask
+     */
+    int getParticipantMask() {
+      return participantMask;
+    }
+
+    /**
+     * Waits until all participants have called {@code await()}.  This method operates as
+     * if calling {@link #await(String) await(null)}.
+     *
+     * @return a number corresponding to the arrival order of this {@code participant}; zero indicates the
+     *      last participant to arrive and the barrier's current wait is complete
+     * @throws IOException
+     *        if an error is raised while reading from or writing to the sync file
+     * @throws InterruptedException
+     *        if this thread is interrupted before or during this method's execution
+     * @throws BrokenBarrierException
+     *        if this barrier is placed in a state inconsistent with normal coordination processing
+     * @throws IllegalStateException
+     *        if this participant is de-registered
+     */
+    public int await() throws BrokenBarrierException, IOException, InterruptedException {
+      return await(null);
+    }
+
+    /**
+     * Waits until all participants have called {@code await()}.  This method changes the associated
+     * {@link InterprocessCyclicBarrier} {@code syncFile} to record the specified participant's "arrival"
+     * and polls participant status until all participants have arrived or the barrier is broken.
+     * <p>
+     * The barrier is marked as <i>broken</i> if:
+     * <ul>
+     *   <li>the executing thread is interrupted</li>
+     *   <li>the barrier is marked as TERMINATING on entry to {@code await}; this indicates one or more
+     *   participants have de-registered without proper coordination of {@code await} calls</li>
+     *   <li>the barrier is marked as TERMINATING while polling for completion and the barrier generation
+     *   has not advanced; this indicates one or more participants have de-registered without reaching the
+     *   current await coordination point</li>
+     * </ul>
+     *
+     * @param loggingContext an identifier to include in trace output of the barrier; may be null
+     * @return a number corresponding to the arrival order of this {@code participant}; zero indicates the
+     *      last participant to arrive and the barrier's current wait is complete
+     * @throws IOException
+     *        if an error is raised while reading from or writing to the sync file
+     * @throws InterruptedException
+     *        if this thread is interrupted before or during this method's execution
+     * @throws BrokenBarrierException
+     *        if this barrier is placed in a state inconsistent with normal coordination processing
+     * @throws IllegalStateException
+     *        if this participant is de-registered
+     */
+    @SuppressWarnings("UnusedReturnValue")
+    public int await(String loggingContext) throws BrokenBarrierException, IOException, InterruptedException {
+      return InterprocessCyclicBarrier.this.await(this, loggingContext);
+    }
+
+    /**
+     * De-registers this participant from the associated {@link InterprocessCyclicBarrier}.
+     * The associated barrier is marked as {@code TERMINATING}.
+     * <p>
+     * A failure to de-register a participant does not cause a broken barrier.
+     * @throws IOException if an error is raised while reading from or  writing to the sync file
+     */
+    public void deregister() throws IOException {
+      InterprocessCyclicBarrier.this.deregister(this);
+    }
+
+    /**
+     * Closes this {@code Participant} by calling {@link #deregister}.
+     * @throws IOException if thrown by {@code deregister}
+     */
+    @Override
+    public void close() throws IOException {
+      this.deregister();
+    }
+
+    @Override
+    public String toString() {
+      StringBuilder sb = new StringBuilder("Participant{");
+      sb.append("participantMask=0x").append(Integer.toHexString(participantMask));
+      sb.append(", syncFile=").append(InterprocessCyclicBarrier.this.syncFile);
+      sb.append(", registered=").append(registered);
+      sb.append('}');
+      return sb.toString();
+    }
+  }
+
+  /**
+   * Isolates the I/O constructs needed to manipulate the barrier sync file.
+   */
+  @SuppressWarnings("UnusedReturnValue")
+  private static final class BarrierAccessor implements AutoCloseable {
+
+    /**
+     * {@link Offsets#FLAGS FLAGS} mask indicating this barrier is broken.
+     */
+    private static final int BARRIER_BROKEN = 0x01;
+    /**
+     * {@link Offsets#FLAGS FLAGS} mask indicating this barrier is terminating.
+     * The first participant calling {@link #deregister} or {@link InterprocessCyclicBarrier#close()}
+     * sets this value; callers already in {@link #await} complete the wait normally iff all participants
+     * have coordinated {@linkplain #await} calls; new entrants to {@linkplain #await} observe a
+     * {@link BrokenBarrierException}.
+     */
+    private static final int BARRIER_TERMINATING = 0x02;
+
+    private final RandomAccessFile file;
+    private final FileChannel channel;
+    private final MappedByteBuffer buffer;
+
+    private BarrierAccessor(Path syncFile) throws IOException {
+      this.file = new RandomAccessFile(syncFile.toFile(), "rwd");
+      this.channel = this.file.getChannel();
+      this.buffer = this.channel.map(FileChannel.MapMode.READ_WRITE, 0, Offsets.size());
+      load(this.buffer);
+    }
+
+    /**
+     * Execute the supplied task while holding a lock on the {@code FileChannel} for this
+     * {@code BarrierAccessor}.  If {@code task} completed normally, this method calls
+     * {@link #force(MappedByteBuffer) force} to flush the buffer.
+     * @param task the task to run
+     * @return a value calculated by {@code task}
+     * @param <T> the type of the return value
+     * @throws IOException
+     *        if an error is raised while accessing the barrier file
+     */
+    @SuppressWarnings("try")
+    <T> T underLock(IOBiFunction<BarrierAccessor, BarrierRecord, T> task) throws IOException {
+      try (FileLock ignored = channel.lock()) {
+        T result = task.apply(this, this.get());
+        force(buffer);
+        return result;
+      } catch (UncheckedIOException e) {
+        throw e.getCause();
+      }
+    }
+
+    /**
+     * Gets the current {@code BarrierRecord} values while holding a lock on the {@code FileChannel}
+     * for this {@code BarrierAccessor}.
+     * @return a new {@code BarrierRecord} holding the current barrier values
+     * @throws IOException
+     *        if an error is raised while accessing the barrier file
+     */
+    @SuppressWarnings("try")
+    BarrierRecord getUnderLock() throws IOException {
+      try (FileLock ignored = channel.lock()) {
+        return get();
+      } catch (UncheckedIOException e) {
+        throw e.getCause();
+      }
+    }
+
+    /**
+     * Gets the current {@code BarrierRecord} values for a caller already holding the appropriate lock.
+     * @return a new {@code BarrierRecord} instance holding the current barrier values
+     * @throws UncheckedIOException if this {@code BarrierAccessor} is closed
+     */
+    private BarrierRecord get() {
+      checkClosed();
+      if (buffer.limit() == 0) {
+        return null;
+      } else {
+        return new BarrierRecord(
+            Offsets.COUNT.get(buffer),
+            Offsets.FLAGS.get(buffer),
+            Offsets.GENERATION.get(buffer),
+            Offsets.ACTIVE_MASK.get(buffer),
+            Offsets.PENDING_MASK.get(buffer)
+        );
+      }
+    }
+
+    /**
+     * Replaces the value for the barrier participant count.
+     * @param participantCount the count to set
+     * @return this {@code BarrierAccessor}
+     * @throws UncheckedIOException if this {@code BarrierAccessor} is closed
+     */
+    BarrierAccessor participantCount(int participantCount) {
+      checkClosed();
+      Offsets.COUNT.put(buffer, participantCount);
+      return this;
+    }
+
+    /**
+     * Set this barrier as BROKEN.
+     * @return this {@code BarrierAccessor}
+     * @throws UncheckedIOException if this {@code BarrierAccessor} is closed
+     */
+    BarrierAccessor setBroken() {
+      checkClosed();
+      int broken = Offsets.FLAGS.get(buffer) | BARRIER_BROKEN;
+      Offsets.FLAGS.put(buffer, broken);
+      return this;
+    }
+
+    /**
+     * Set this barrier as TERMINATING.
+     * @return this {@code BarrierAccessor}
+     * @throws UncheckedIOException if this {@code BarrierAccessor} is closed
+     */
+    BarrierAccessor setTerminating() {
+      checkClosed();
+      int terminating = Offsets.FLAGS.get(buffer) | BARRIER_TERMINATING;
+      Offsets.FLAGS.put(buffer, terminating);
+      return this;
+    }
+
+    /**
+     * Replaces the value for the barrier generation.
+     * @param generation the generation number to set
+     * @return this {@code BarrierAccessor}
+     * @throws UncheckedIOException if this {@code BarrierAccessor} is closed
+     */
+    BarrierAccessor generation(int generation) {
+      checkClosed();
+      Offsets.GENERATION.put(buffer, generation);
+      return this;
+    }
+
+    /**
+     * Replaces the value for the barrier active participant mask.
+     * @param activeMask the active mask value to set
+     * @return this {@code BarrierAccessor}
+     * @throws UncheckedIOException if this {@code BarrierAccessor} is closed
+     */
+    BarrierAccessor activeMask(int activeMask) {
+      checkClosed();
+      Offsets.ACTIVE_MASK.put(buffer, activeMask);
+      return this;
+    }
+
+    /**
+     * Replaces the value for the barrier pending participant mask.
+     * @param pendingMask the pending mask value to set
+     * @return this {@code BarrierAccessor}
+     * @throws UncheckedIOException if this {@code BarrierAccessor} is closed
+     */
+    BarrierAccessor pendingMask(int pendingMask) {
+      checkClosed();
+      Offsets.PENDING_MASK.put(buffer, pendingMask);
+      return this;
+    }
+
+    @Override
+    public void close() throws IOException {
+      // Closes the FileChannel as well ...
+      file.close();
+    }
+
+    /**
+     * Indicates if this {@code BarrierAccessor} is closed.
+     * @return {@code true} if this {@code BarrierAccessor} is closed; {@code false} if open
+     */
+    boolean isClosed() {
+      return !channel.isOpen();
+    }
+
+    private void checkClosed() {
+      if (!channel.isOpen()) {
+        throw new UncheckedIOException(new ClosedChannelException());
+      }
+    }
+
+    private enum Offsets {
+      /**
+       * The number of participants in the {@code InterprocessCyclicBarrier}.
+       */
+      COUNT(0),
+      /**
+       * Hold state flags for the {@code InterprocessCyclicBarrier}.
+       * @see #BARRIER_BROKEN
+       * @see #BARRIER_TERMINATING
+       */
+      FLAGS(4),
+      /**
+       * Holds the "generation" of the {@code InterprocessCyclicBarrier}.  A new barrier starts with a
+       * generation of zero, advancing by one for each successful coordinated await group.
+       */
+      GENERATION(8),
+      /**
+       * A bitmask indicating the participants registered in the {@code InterprocessCyclicBarrier}.
+       */
+      ACTIVE_MASK(12),
+      /**
+       * A bitmask indicating the participants that have <b>not yet</b> called {@link InterprocessCyclicBarrier#await}
+       * in the current generation.
+       */
+      PENDING_MASK(16),
+      ;
+      final int offset;
+
+      Offsets(int offset) {
+        this.offset = offset;
+      }
+
+      public int get(ByteBuffer buffer) {
+        return buffer.getInt(offset);
+      }
+
+      public void put(ByteBuffer buffer, int value) {
+        buffer.putInt(offset, value);
+      }
+
+      /**
+       * Gets the byte length of the {@code Offsets}.
+       * @return the {@code Offsets} size
+       */
+      public static int size() {
+        Offsets[] values = values();
+        int lastOffset = values[values.length - 1].offset;
+        return lastOffset + Integer.BYTES;
+      }
+    }
+  }
+
+  @FunctionalInterface
+  private interface IOBiFunction<T, U, V> {
+    V apply(T t, U u) throws IOException;
+  }
+
+  private static class Broken extends IOException {
+    private static final long serialVersionUID = -7618496492560957289L;
+    public Broken() {
+    }
+  }
+
+  // Package-private for testing
+  static final class BarrierRecord {
+    private final int participantCount;
+    private final int flags;
+    private final int generation;
+    private final int activeMask;
+    private final int pendingMask;
+
+    private BarrierRecord(int participantCount, int flags, int generation, int activeMask, int pendingMask) {
+      this.participantCount = participantCount;
+      this.flags = flags;
+      this.generation = generation;
+      this.activeMask = activeMask;
+      this.pendingMask = pendingMask;
+    }
+
+    boolean isBroken() {
+      return (flags & BarrierAccessor.BARRIER_BROKEN) != 0;
+    }
+
+    boolean isTerminating() {
+      return (flags & BarrierAccessor.BARRIER_TERMINATING) != 0;
+    }
+
+    int participantCount() {
+      return participantCount;
+    }
+
+    int generation() {
+      return generation;
+    }
+
+    int activeMask() {
+      return activeMask;
+    }
+
+    int pendingMask() {
+      return pendingMask;
+    }
+  }
+}

--- a/tools/src/test/java/org/terracotta/utilities/concurrent/InterprocessCyclicBarrierTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/concurrent/InterprocessCyclicBarrierTest.java
@@ -1,0 +1,506 @@
+/*
+ * Copyright 2022 Terracotta, Inc., a Software AG company.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.utilities.concurrent;
+
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.terracotta.org.junit.rules.TemporaryFolder;
+
+import java.nio.channels.ClosedByInterruptException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.terracotta.utilities.test.matchers.ThrowsMatcher.threw;
+
+/**
+ * Test for {@link InterprocessCyclicBarrier}.
+ */
+public class InterprocessCyclicBarrierTest  {
+
+  @Rule
+  public final TestName testName = new TestName();
+
+  @Rule
+  public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @SuppressWarnings("resource")
+  @Test
+  public void testCtorBad() throws Exception {
+    Path syncFile = temporaryFolder.newFile(testName.getMethodName()).toPath();
+    assertThat(() -> new InterprocessCyclicBarrier(0, syncFile), threw(instanceOf(IllegalArgumentException.class)));
+    assertThat(() -> new InterprocessCyclicBarrier(1, syncFile), threw(instanceOf(IllegalArgumentException.class)));
+    assertThat(() -> new InterprocessCyclicBarrier(2, null), threw(instanceOf(NullPointerException.class)));
+  }
+
+  @SuppressWarnings({"EmptyTryBlock", "try"})
+  @Test
+  public void testCtor() throws Exception {
+    Path syncFile = temporaryFolder.newFile(testName.getMethodName()).toPath();
+    try (InterprocessCyclicBarrier ignored = new InterprocessCyclicBarrier(2, syncFile)) {
+      // empty
+    }
+  }
+
+  @SuppressWarnings({"resource", "try"})
+  @Test
+  public void testParticipantMismatch() throws Exception {
+    Path syncFile = temporaryFolder.newFile(testName.getMethodName()).toPath();
+    try (InterprocessCyclicBarrier outerBarrier = new InterprocessCyclicBarrier(2, syncFile)) {
+      assertThat(() -> new InterprocessCyclicBarrier(3, syncFile), threw(instanceOf(IllegalStateException.class)));
+      assertThat(outerBarrier::register, threw(instanceOf(BrokenBarrierException.class)));
+      assertTrue(outerBarrier.isBroken());
+    }
+  }
+
+  @Test
+  public void testRegisterAll() throws Exception {
+    Path syncFile = temporaryFolder.newFile(testName.getMethodName()).toPath();
+    int participantCount = 2;
+    try (InterprocessCyclicBarrier barrier = new InterprocessCyclicBarrier(participantCount, syncFile)) {
+      List<InterprocessCyclicBarrier.Participant> participants = new ArrayList<>();
+      int aggregateParticipantMask = 0;
+      for (int i = 0; i < participantCount; i++) {
+        InterprocessCyclicBarrier.Participant id = barrier.register();
+        assertThat(Integer.bitCount(id.getParticipantMask()), is(1));
+        aggregateParticipantMask |= id.getParticipantMask();
+        participants.add(id);
+      }
+      assertThat(Integer.bitCount(aggregateParticipantMask), is(participantCount));
+      assertThat(barrier::register, threw(instanceOf(IllegalStateException.class)));
+      assertTrue(participants.stream().allMatch(InterprocessCyclicBarrier.Participant::isRegistered));
+      assertFalse(barrier.isBroken());
+
+      InterprocessCyclicBarrier.BarrierRecord record = barrier.get();
+      assertThat(record.activeMask(), is(aggregateParticipantMask));
+      assertThat(record.pendingMask(), is(aggregateParticipantMask));
+    }
+  }
+
+  @Test
+  public void testRegisterDeregister() throws Exception {
+    Path syncFile = temporaryFolder.newFile(testName.getMethodName()).toPath();
+    try (InterprocessCyclicBarrier barrier = new InterprocessCyclicBarrier(2, syncFile)) {
+      InterprocessCyclicBarrier.Participant id = barrier.register();
+      assertTrue(id.isRegistered());
+
+      InterprocessCyclicBarrier.BarrierRecord record = barrier.get();
+      assertThat(record.participantCount(), is(2));
+      assertThat(Integer.bitCount(record.activeMask()), is(1));
+      assertThat(Integer.bitCount(record.pendingMask()), is(2));
+
+      barrier.deregister(id);
+      assertFalse(id.isRegistered());
+
+      record = barrier.get();
+      assertThat(Integer.bitCount(record.activeMask()), is(0));
+      assertThat(Integer.bitCount(record.pendingMask()), is(1));
+      assertTrue(record.isTerminating());
+    }
+  }
+
+  @Test
+  public void testRegisterClose() throws Exception {
+    Path syncFile = temporaryFolder.newFile(testName.getMethodName()).toPath();
+    InterprocessCyclicBarrier.Participant id;
+    try (InterprocessCyclicBarrier barrier = new InterprocessCyclicBarrier(2, syncFile)) {
+      id = barrier.register();
+      assertTrue(id.isRegistered());
+    }
+    assertFalse(id.isRegistered());
+  }
+
+  @SuppressWarnings({ "resource", "ResultOfMethodCallIgnored" })
+  @Test
+  public void testInterruptBeforeCtor() throws Exception {
+    Path syncFile = temporaryFolder.newFile(testName.getMethodName()).toPath();
+    Thread.currentThread().interrupt();
+    try {
+      assertThat(() -> new InterprocessCyclicBarrier(2, syncFile), threw(instanceOf(ClosedByInterruptException.class)));
+      assertTrue(Thread.currentThread().isInterrupted());
+    } finally {
+      Thread.interrupted();
+    }
+  }
+
+  @Test
+  public void testInterruptBeforeRegister() throws Exception {
+    Path syncFile = temporaryFolder.newFile(testName.getMethodName()).toPath();
+    try (InterprocessCyclicBarrier barrier = new InterprocessCyclicBarrier(2, syncFile)) {
+      Thread.currentThread().interrupt();
+      assertThat(barrier::register, threw(instanceOf(InterruptedException.class)));
+      assertFalse(Thread.currentThread().isInterrupted());
+      assertThat(barrier::register, threw(instanceOf(BrokenBarrierException.class)));
+      assertTrue(barrier.isBroken());
+    }
+  }
+
+  @SuppressWarnings("ResultOfMethodCallIgnored")
+  @Test
+  public void testInterruptBeforeDeregister() throws Exception {
+    Path syncFile = temporaryFolder.newFile(testName.getMethodName()).toPath();
+    try (InterprocessCyclicBarrier barrier = new InterprocessCyclicBarrier(2, syncFile)) {
+      InterprocessCyclicBarrier.Participant id = barrier.register();
+      Thread.currentThread().interrupt();
+      try {
+        id.deregister();
+        assertFalse(id.isRegistered());
+        assertTrue(Thread.currentThread().isInterrupted());
+      } finally {
+        Thread.interrupted();   // Clear the interrupt
+      }
+      assertFalse(barrier.isBroken());
+    }
+  }
+
+  @SuppressWarnings("ResultOfMethodCallIgnored")
+  @Test
+  public void testInterruptBeforeClose() throws Exception {
+    Path syncFile = temporaryFolder.newFile(testName.getMethodName()).toPath();
+    int participantCount = 2;
+    List<InterprocessCyclicBarrier.Participant> participants = new ArrayList<>();
+    InterprocessCyclicBarrier barrier = new InterprocessCyclicBarrier(participantCount, syncFile);
+    try {
+      for (int i = 0; i < participantCount; i++) {
+        participants.add(barrier.register());
+      }
+
+    } finally {
+      Thread.currentThread().interrupt();
+      try {
+        barrier.close();
+      } finally {
+        Thread.interrupted();
+      }
+    }
+    assertFalse(barrier.isBroken());
+    assertTrue(participants.stream().noneMatch(InterprocessCyclicBarrier.Participant::isRegistered));
+
+    InterprocessCyclicBarrier.BarrierRecord record = barrier.get();
+    assertTrue(record.isTerminating());
+    assertThat(record.activeMask(), is(0));
+    assertThat(record.pendingMask(), is(0));
+  }
+
+  @Test
+  public void testTwoThreadsCommonBarrierEarlyDeregister() throws Exception {
+    Path syncFile = temporaryFolder.newFile(testName.getMethodName()).toPath();
+    ExecutorService executorService = Executors.newFixedThreadPool(2);
+    CyclicBarrier observerBarrier = new CyclicBarrier(3);
+    try (InterprocessCyclicBarrier barrier = new InterprocessCyclicBarrier(2, syncFile)) {
+
+      // First task -- this task waits
+      Future<Void> waitingTask = executorService.submit(() -> {
+        InterprocessCyclicBarrier.Participant participant = barrier.register();
+        observerBarrier.await();      // Align everyone to participant registration
+        observerBarrier.await();      // Allow observer to examine barrier state
+        observerBarrier.await();      // Wait for de-registeringTask to deregister
+        participant.await();
+        fail("Expecting BrokenBarrierException");
+        return null;
+      });
+
+      // Second task -- this task just de-registers
+      Future<Void> deregisteringTask = executorService.submit(() -> {
+        InterprocessCyclicBarrier.Participant participant = barrier.register();
+        observerBarrier.await();      // Align everyone to participant registration
+        observerBarrier.await();      // Allow observer to examine barrier state
+        participant.deregister();
+        observerBarrier.await();      // Permit waitingTask to continue with wait
+        return null;
+      });
+
+      observerBarrier.await();      // Align everyone to participant registration
+
+      InterprocessCyclicBarrier.BarrierRecord record = barrier.get();
+      assertThat(Integer.bitCount(record.activeMask()), is(2));
+      assertThat(Integer.bitCount(record.pendingMask()), is(2));
+      observerBarrier.await();      // State examination complete; let tasks continue
+
+      observerBarrier.await();      // Let wait/de-registration continue
+
+      assertThat(waitingTask::get, threw(
+          allOf(
+              instanceOf(ExecutionException.class),
+              hasProperty("cause", instanceOf(BrokenBarrierException.class)))));
+      assertNull(deregisteringTask.get());
+
+      assertTrue(barrier.isBroken());
+    }
+  }
+
+  @Test
+  public void testSharedParticipantAwaitDeregister() throws Exception {
+    Path syncFile = temporaryFolder.newFile(testName.getMethodName()).toPath();
+    ExecutorService executorService = Executors.newFixedThreadPool(2);
+    CyclicBarrier observerBarrier = new CyclicBarrier(3);
+    try (InterprocessCyclicBarrier barrier = new InterprocessCyclicBarrier(2, syncFile)) {
+
+      InterprocessCyclicBarrier.Participant participant = barrier.register();
+      int participantMask = participant.getParticipantMask();
+
+      // First task -- this task waits
+      Future<Void> waitingTask = executorService.submit(() -> {
+        observerBarrier.await();      // Align everyone to thread running
+        participant.await();
+        fail("Expecting BrokenBarrierException");
+        return null;
+      });
+
+      // Second task -- this task just de-registers
+      Future<Void> deregisteringTask = executorService.submit(() -> {
+        observerBarrier.await();      // Align everyone to thread running
+
+        // Wait until participant's pending mask is cleared
+        while ((barrier.get().pendingMask() & participantMask) != 0) {
+          TimeUnit.MILLISECONDS.sleep(50L);
+        }
+
+        participant.deregister();
+        return null;
+      });
+
+      observerBarrier.await();      // Align everyone to participant registration
+
+      assertNull(deregisteringTask.get(15L, TimeUnit.SECONDS));
+      assertThat(waitingTask::get, threw(
+          allOf(
+              instanceOf(ExecutionException.class),
+              hasProperty("cause", instanceOf(BrokenBarrierException.class)))));
+
+      assertTrue(barrier.isBroken());
+    }
+  }
+
+  @Test
+  public void testTwoThreadsCommonBarrierAwaitDeregister() throws Exception {
+    Path syncFile = temporaryFolder.newFile(testName.getMethodName()).toPath();
+    ExecutorService executorService = Executors.newFixedThreadPool(2);
+    CyclicBarrier observerBarrier = new CyclicBarrier(2);
+    try (InterprocessCyclicBarrier barrier = new InterprocessCyclicBarrier(2, syncFile)) {
+
+      int[] participantMask = new int[1];
+      // First task -- this task waits
+      Future<Void> waitingTask = executorService.submit(() -> {
+        InterprocessCyclicBarrier.Participant participant = barrier.register();
+        participantMask[0] = participant.getParticipantMask();
+        observerBarrier.await();      // Align everyone to participant registration
+        participant.await();
+        fail("Expecting BrokenBarrierException");
+        return null;
+      });
+
+      // Second task -- this task just de-registers
+      Future<Void> deregisteringTask = executorService.submit(() -> {
+        InterprocessCyclicBarrier.Participant participant = barrier.register();
+        observerBarrier.await();      // Align everyone to participant registration
+
+        // Wait until participant's pending mask is cleared
+        while ((barrier.get().pendingMask() & participantMask[0]) != 0) {
+          TimeUnit.MILLISECONDS.sleep(50L);
+        }
+
+        participant.deregister();
+        return null;
+      });
+
+      assertThat(() -> waitingTask.get(15L, TimeUnit.SECONDS), threw(
+          allOf(
+              instanceOf(ExecutionException.class),
+              hasProperty("cause", instanceOf(BrokenBarrierException.class)))));
+      assertNull(deregisteringTask.get());
+
+      assertTrue(barrier.isBroken());
+    }
+  }
+
+  @SuppressWarnings("ResultOfMethodCallIgnored")
+  @Test
+  public void testTwoThreadsCommonBarrierInterruptedBeforeRegister() throws Exception {
+    Path syncFile = temporaryFolder.newFile(testName.getMethodName()).toPath();
+    ExecutorService executorService = Executors.newFixedThreadPool(2);
+    CyclicBarrier observerBarrier = new CyclicBarrier(3);
+    try (InterprocessCyclicBarrier barrier = new InterprocessCyclicBarrier(2, syncFile)) {
+
+      // First task -- this task waits
+      Future<Void> waitingTask = executorService.submit(() -> {
+        InterprocessCyclicBarrier.Participant participant = barrier.register();
+        observerBarrier.await();      // Align everyone to participant registration
+        participant.await();
+        fail("Expecting BrokenBarrierException");
+        return null;
+      });
+
+      // Second task -- this task interrupts register
+      Future<Void> interruptedTask = executorService.submit(() -> {
+        Thread.currentThread().interrupt();
+        try {
+          barrier.register();
+          fail("Expecting InterruptedException");
+        } finally {
+          Thread.interrupted();         // Reset interruption
+          observerBarrier.await();      // Align everyone to participant registration
+        }
+        return null;
+      });
+
+      observerBarrier.await();      // Align everyone to participant registration
+
+      assertThat(() -> waitingTask.get(15L, TimeUnit.SECONDS), threw(
+          allOf(
+              instanceOf(ExecutionException.class),
+              hasProperty("cause", instanceOf(BrokenBarrierException.class)))));
+      assertThat(interruptedTask::get, threw(
+          allOf(
+              instanceOf(ExecutionException.class),
+              hasProperty("cause", instanceOf(InterruptedException.class)))));
+
+      assertTrue(barrier.isBroken());
+    }
+  }
+
+  @SuppressWarnings("ResultOfMethodCallIgnored")
+  @Test
+  public void testTwoThreadsCommonBarrierInterruptedBeforeWait() throws Exception {
+    Path syncFile = temporaryFolder.newFile(testName.getMethodName()).toPath();
+    ExecutorService executorService = Executors.newFixedThreadPool(2);
+    CyclicBarrier observerBarrier = new CyclicBarrier(3);
+    try (InterprocessCyclicBarrier barrier = new InterprocessCyclicBarrier(2, syncFile)) {
+
+      // First task -- this task waits
+      Future<Void> waitingTask = executorService.submit(() -> {
+        InterprocessCyclicBarrier.Participant participant = barrier.register();
+        observerBarrier.await();      // Align everyone to participant registration
+        observerBarrier.await();      // Wait for interrupted thread to enter await
+        participant.await();
+        fail("Expecting BrokenBarrierException");
+        return null;
+      });
+
+      // Second task -- this task interrupts before await
+      Future<Void> interruptedTask = executorService.submit(() -> {
+        InterprocessCyclicBarrier.Participant participant = barrier.register();
+        observerBarrier.await();      // Align everyone to participant registration
+        Thread.currentThread().interrupt();
+        try {
+          participant.await();
+          fail("Expecting InterruptedException");
+        } finally {
+          observerBarrier.await();      // Permit waitingTask to continue with wait
+          Thread.interrupted();         // Reset interruption
+        }
+        return null;
+      });
+
+      observerBarrier.await();      // Align everyone to participant registration
+      observerBarrier.await();      // Let wait/interruption continue
+
+      assertThat(() -> waitingTask.get(15L, TimeUnit.SECONDS), threw(
+          allOf(
+              instanceOf(ExecutionException.class),
+              hasProperty("cause", instanceOf(BrokenBarrierException.class)))));
+      assertThat(interruptedTask::get, threw(
+          allOf(instanceOf(ExecutionException.class),
+              hasProperty("cause", is(instanceOf(InterruptedException.class))))));
+
+      assertTrue(barrier.isBroken());
+    }
+  }
+
+  @Test
+  public void testTwoThreadsCommonBarrierTwoWaitNormal() throws Exception {
+    Path syncFile = temporaryFolder.newFile(testName.getMethodName()).toPath();
+    int participantCount = 2;
+    int waitCount = 5;
+    ExecutorService executorService = Executors.newFixedThreadPool(participantCount);
+    CyclicBarrier observerBarrier = new CyclicBarrier(participantCount + 1);
+    try (InterprocessCyclicBarrier barrier = new InterprocessCyclicBarrier(participantCount, syncFile)) {
+
+      List<Future<List<Integer>>> tasks = new ArrayList<>();
+      for (int i = 0; i < participantCount; i++) {
+        tasks.add(executorService.submit(() -> {
+          List<Integer> arrivalOrders = new ArrayList<>();
+          InterprocessCyclicBarrier.Participant participant = barrier.register();
+          observerBarrier.await();      // Align everyone to participant registration
+          for (int j = 0; j < waitCount; j++) {
+            arrivalOrders.add(participant.await());
+          }
+          return arrivalOrders;
+        }));
+      }
+
+      observerBarrier.await();      // Align everyone to participant registration
+
+      List<List<Integer>> taskArrivalOrders = new ArrayList<>();
+      for (Future<List<Integer>> future : tasks) {
+        taskArrivalOrders.add(future.get());
+      }
+
+      assertFalse(barrier.isBroken());
+
+      for (List<Integer> arrivalOrders : taskArrivalOrders) {
+        assertTrue(arrivalOrders.stream().mapToInt(Integer::intValue).allMatch(i -> i >= 0 && i < participantCount));
+      }
+
+      // Ensure each arrival order is represented in each wait attempt
+      assertTrue(taskArrivalOrders.stream().allMatch(l -> l.size() == waitCount));
+      for (int i = 0; i < waitCount; i++) {
+        int aggregateMask = 0;
+        for (List<Integer> arrivalOrders : taskArrivalOrders) {
+          aggregateMask |= 0x01 << arrivalOrders.get(i);
+        }
+        assertThat(Integer.bitCount(aggregateMask), is(participantCount));
+      }
+    }
+  }
+
+  @Test
+  public void testCloseSetsTerminate() throws Exception {
+    Path syncFile = temporaryFolder.newFile(testName.getMethodName()).toPath();
+    InterprocessCyclicBarrier barrier = new InterprocessCyclicBarrier(2, syncFile);
+
+    InterprocessCyclicBarrier.BarrierRecord record;
+    try {
+      record = barrier.get();
+      assertFalse(record.isTerminating());
+      assertFalse(record.isBroken());
+    } finally {
+      barrier.close();
+    }
+
+    record = barrier.get();
+    assertTrue(record.isTerminating());
+    assertFalse(record.isBroken());
+  }
+}

--- a/tools/src/test/java/org/terracotta/utilities/io/FilesCreateTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/io/FilesCreateTest.java
@@ -1,0 +1,368 @@
+/*
+ * Copyright 2022 Terracotta, Inc., a Software AG company.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.utilities.io;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.terracotta.utilities.concurrent.InterprocessCyclicBarrier;
+import org.terracotta.utilities.test.Diagnostics;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.management.ManagementFactory;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.FileAttribute;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static java.lang.reflect.Modifier.isStatic;
+import static java.util.regex.Pattern.compile;
+import static java.util.regex.Pattern.quote;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
+import static org.terracotta.utilities.test.matchers.ThrowsMatcher.threw;
+
+/**
+ * Provides tests for the {@link Files#createFile(Path, FileAttribute[])} method.
+ */
+public class FilesCreateTest extends FilesTestBase {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(FilesCreateTest.class);
+
+
+  @Test
+  public void testNullArgs() {
+    assertThat(() -> Files.createFile(null), threw(instanceOf(NullPointerException.class)));
+    assertThat(() -> Files.createFile(null, Duration.ofSeconds(1L)), threw(instanceOf(NullPointerException.class)));
+    assertThat(() -> Files.createFile(topFile, (Duration)null), threw(instanceOf(NullPointerException.class)));
+    assertThat(() -> Files.createFile(topFile, Duration.ofSeconds(1L), (FileAttribute<?>)null), threw(instanceOf(NullPointerException.class)));
+  }
+
+  @Test
+  public void testExistingFile() {
+    assertThat(() -> Files.createFile(topFile), threw(instanceOf(FileAlreadyExistsException.class)));
+  }
+
+  @Test
+  public void testExistingDirectory() {
+    if (isWindows) {
+      // Windows throws an AccessDeniedException when attempting to create a file over an existing director/directory link
+      assertThat(() -> Files.createFile(top), threw(instanceOf(AccessDeniedException.class)));
+    } else {
+      assertThat(() -> Files.createFile(top), threw(instanceOf(FileAlreadyExistsException.class)));
+    }
+  }
+
+  @Test
+  public void testExistingFileLink() {
+    assumeTrue("Skipped because symbolic links cannot be created in current environment", symlinksSupported);
+    assertThat(() -> Files.createFile(fileLink), threw(instanceOf(FileAlreadyExistsException.class)));
+  }
+
+  @Test
+  public void testExistingDirectoryLink() {
+    assumeTrue("Skipped because symbolic links cannot be created in current environment", symlinksSupported);
+    if (isWindows) {
+      // Windows throws an AccessDeniedException when attempting to create a file over an existing director/directory link
+      assertThat(() -> Files.createFile(dirLink), threw(instanceOf(AccessDeniedException.class)));
+    } else {
+      assertThat(() -> Files.createFile(dirLink), threw(instanceOf(FileAlreadyExistsException.class)));
+    }
+  }
+
+  /**
+   * Tests {@link Files#createFile(Path, FileAttribute[])} when the target is a file <i>marked</i> for
+   * deletion on Windows.  This test relies on an external process to open and delete the file.  (Different
+   * failures are observed when this is done in-process.)
+   */
+  @SuppressWarnings({"try"})
+  @Test
+  public void testDeletedFile() throws Exception {
+    assumeTrue("Skipped -- Windows-specific behavior", isWindows);
+
+    try (MDC.MDCCloseable ignored = MDC.putCloseable("PID", Long.toString(Diagnostics.getLongPid()))) {
+
+      Path syncFile = TEST_ROOT.newFile(testName.getMethodName() + "_syncFile").toPath();
+      assertTrue(java.nio.file.Files.exists(topFile));
+
+      Process process = spawn("backgroundDelete", syncFile.toString(), topFile.toString());
+      Thread outputThread = new Thread(() -> {
+        try {
+          InputStream stream = process.getInputStream();
+          int b;
+          while ((b = stream.read()) != -1) {
+            System.out.write(b);
+          }
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      });
+      outputThread.setDaemon(true);
+      outputThread.start();
+
+      try {
+        try (InterprocessCyclicBarrier barrier = new InterprocessCyclicBarrier(3, syncFile)) {
+          InterprocessCyclicBarrier.Participant participant = barrier.register();
+
+          participant.await("file open");             // Align to file open
+
+          assertThat(() -> Files.createFile(topFile, Duration.ofMillis(250L)),
+              threw(instanceOf(FileAlreadyExistsException.class)));
+
+          participant.await("post-create-A");         // Align post-file create A attempt
+          participant.await("post-close-A");          // Align post-close in first thread
+
+          /*
+           * At this point, the file is marked deleted but still exists because the second
+           * thread in the background process is holding it open.  The following pair of
+           * assertions may seem paradoxical but, on Windows, open files are 'marked' deleted
+           * (both 'exists' == false and 'notExists' == false) but not actually deleted until
+           * all file handles for the file are closed.
+           */
+          assertFalse("topFile is not 'marked' for deletion", java.nio.file.Files.exists(topFile));
+          assertFalse("topFile is not 'marked' for deletion", java.nio.file.Files.notExists(topFile));
+
+          assertThat(() -> Files.createFile(topFile, Duration.ofMillis(250L)),
+              threw(instanceOf(AccessDeniedException.class)));
+
+          participant.await("post-create-B");         // Align post-file create B attempt
+          participant.await("post-close-B");          // Align post-close in second thread
+
+          Files.createFile(topFile, Duration.ofMillis(250L));
+        }
+      } finally {
+        process.waitFor();        // Ensure all background stdout is complete
+      }
+    }
+  }
+
+  /**
+   * Off-process companion to {@link #testDeletedFile()} to set up conditions for a file
+   * <i>marked</i> for deletion but not yet deleted.
+   * @param syncFileName the {@link InterprocessCyclicBarrier} sync file
+   * @param targetFileName the file to mark for deletion
+   */
+  // Used symbolically
+  @SuppressWarnings({ "TryFinallyCanBeTryWithResources", "unused", "ThrowFromFinallyBlock" })
+  private static void backgroundDelete(String syncFileName, String targetFileName)
+      throws IOException, BrokenBarrierException, InterruptedException {
+
+    Path syncFile = Paths.get(syncFileName);
+    Path targetPath = Paths.get(targetFileName);
+
+    try (InterprocessCyclicBarrier barrier = new InterprocessCyclicBarrier(3, syncFile)) {
+
+      // Background, in-process thread to hold open a file handle
+      Map<String, String> mdc = MDC.getCopyOfContextMap();
+      FutureTask<Void> task = new FutureTask<>(() -> {
+        MDC.setContextMap(mdc);
+        holdOpen(barrier, targetPath);
+        return null;
+      });
+      Thread peer = new Thread(task, "peer");
+      peer.setDaemon(true);
+      peer.start();
+
+      Throwable fault = null;
+      try {
+        InterprocessCyclicBarrier.Participant participant = barrier.register();
+
+        SeekableByteChannel channel = java.nio.file.Files.newByteChannel(targetPath, StandardOpenOption.DELETE_ON_CLOSE);
+        try {
+          assertTrue(channel.isOpen());
+          participant.await("file open");             // Align to file open
+          participant.await("post-create-A");         // Align post-file create A attempt
+          channel.close();
+          participant.await("post-close-A");          // Align post-close in this thread
+          participant.await("post-create-B");         // Align post-file create B attempt
+          participant.await("post-close-B");          // Align post-close in other thread
+        } finally {
+          channel.close();
+        }
+      } catch (IOException | BrokenBarrierException | InterruptedException exception) {
+        fault = exception;
+
+      } finally {
+        try {
+          task.get();
+        } catch (ExecutionException e) {
+          Throwable cause = e.getCause();
+          if (fault != null) {
+            fault.addSuppressed(cause);
+            cause = fault;
+          }
+          if (cause instanceof Error) {
+            throw (Error)cause;
+          } else if (cause instanceof RuntimeException) {
+            throw (RuntimeException)cause;
+          } else if (cause instanceof IOException) {
+            throw (IOException)cause;
+          } else if (cause instanceof BrokenBarrierException) {
+            throw (BrokenBarrierException)cause;
+          } else if (cause instanceof InterruptedException) {
+            throw (InterruptedException)cause;
+          } else {
+            throw new RuntimeException(cause);
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Peer of {@link #backgroundDelete(String, String)} to hold open a file handle against {@code targetPath}.
+   * @param barrier the {@code InterprocessCyclicBarrier} shared with {@code backgroundDelete}
+   * @param targetPath the file to open
+   */
+  @SuppressWarnings("try")
+  private static void holdOpen(InterprocessCyclicBarrier barrier, Path targetPath)
+      throws IOException, BrokenBarrierException, InterruptedException {
+    InterprocessCyclicBarrier.Participant participant = barrier.register();
+    try (SeekableByteChannel ignored = java.nio.file.Files.newByteChannel(targetPath)) {
+      participant.await("file open");             // Align to file open
+      participant.await("post-create-A");         // Align post-file create A attempt
+      participant.await("post-close-A");          // Align post-close in other thread
+      participant.await("post-create-B");         // Align post-file create B attempt
+    }
+    participant.await("post-close-B");            // Align post-close in this thread
+  }
+
+  /**
+   * Spawns a Java process to execute the specified method in this class.
+   * @param methodName the name of the method to run
+   * @param methodArguments the arguments to pass to the method
+   * @return the {@code Process} representing the spawned process
+   * @throws IOException if an error is raised while spawning the process
+   * @throws NoSuchMethodException if {@code methodName} does not identify a static void method in this
+   *        class accepting the same number of {@code String} arguments in {@code methodArguments}
+   */
+  @SuppressWarnings("SameParameterValue")
+  private Process spawn(String methodName, String... methodArguments) throws IOException, NoSuchMethodException {
+    findMethod(methodName, methodArguments);        // Validate locally ...
+
+    Path workingDirectory = Paths.get("").toAbsolutePath();
+    Map<String, String> environment = System.getenv();
+
+    // Pass most JVM arguments into spawned Java process
+    Set<Predicate<String>> exclusions = Stream.of(
+            compile("-((cp)|(classpath))=.*"),
+            compile(quote("-Dvisualvm.id=") + ".*"),
+            compile(quote("-Didea.test.cyclic.buffer.size=") + ".*"),
+            compile("-javaagent:.*[/\\\\]idea_rt\\.jar=.*"))
+        .map(Pattern::asPredicate).collect(toSet());
+    List<String> jvmArguments = ManagementFactory.getRuntimeMXBean().getInputArguments().stream()
+        .filter(a -> exclusions.stream().noneMatch(p -> p.test(a)))
+        .collect(toList());
+    if (!jvmArguments.isEmpty()) {
+      LOGGER.info("Propagating JVM arguments: {}", jvmArguments);
+    }
+
+    List<String> commandLine = new ArrayList<>();
+    commandLine.add(Paths.get(System.getProperty("java.home"), "bin", (isWindows ? "java.exe" : "java")).toAbsolutePath().toString());
+    commandLine.addAll(jvmArguments);
+    commandLine.addAll(Arrays.asList("-classpath", System.getProperty("java.class.path")));
+    commandLine.add(this.getClass().getName());
+    commandLine.add(methodName);
+    commandLine.addAll(Arrays.asList(methodArguments));
+
+    ProcessBuilder builder = new ProcessBuilder(commandLine);
+    builder.redirectErrorStream(true);
+    builder.directory(workingDirectory.toFile());
+    builder.environment().putAll(environment);
+    LOGGER.info("Starting {}", builder.command());
+    return builder.start();
+  }
+
+  /**
+   * Main method to extend test case execution into additional processes.
+   * @param args strings as require for the test; the first argument is required; the remainder are processed
+   *             by designated method:
+   * <dl>
+   *   <dt>{@code methodName}</dt>
+   *   <dd>name of the method to run in task</dd>
+   *   <dt>argN</dt>
+   *   <dd>arguments as required by {@code methodName}</dd>
+   * </dl>
+   */
+  @SuppressWarnings("try")
+  public static void main(String[] args) {
+    try (MDC.MDCCloseable ignored = MDC.putCloseable("PID", Long.toString(Diagnostics.getLongPid()))) {
+      LOGGER.info("Entered {}.main({})", FilesCreateTest.class.getName(), Arrays.toString(args));
+      if (args.length == 0) {
+        LOGGER.error("No arguments received");
+        // System.exit(1);
+      } else {
+        String methodName = args[0];
+        String[] methodArguments = new String[args.length - 1];
+        System.arraycopy(args, 1, methodArguments, 0, methodArguments.length);
+        try {
+          Method method = findMethod(methodName, methodArguments);
+          LOGGER.info("Invoking {}.{}({})", FilesCreateTest.class.getName(), methodName, Arrays.toString(methodArguments));
+          method.invoke(null, (Object[])methodArguments);
+          LOGGER.info("Exited {}.{}({})", FilesCreateTest.class.getName(), methodName, Arrays.toString(methodArguments));
+        } catch (InvocationTargetException | IllegalAccessException | NoSuchMethodException e) {
+          LOGGER.error("Failed to execute {}.{}({})", FilesCreateTest.class.getName(), methodName, Arrays.toString(methodArguments), e);
+          // System.exit(2);
+        }
+      }
+      LOGGER.info("Exiting {}.main({})", FilesCreateTest.class.getName(), Arrays.toString(args));
+    }
+  }
+
+  /**
+   * Locates the specified method in this class and ensures it is a static void method accepting the
+   * number of {@code String} arguments in {@code methodArgs}.
+   * @param methodName the method to locale
+   * @param methodArgs the arguments to check; only the count is needed
+   * @return the located method
+   * @throws NoSuchMethodException if the proper method is not found
+   */
+  private static Method findMethod(String methodName, String... methodArgs) throws NoSuchMethodException {
+    Class<?>[] methodArgumentTypes = Stream.generate(() -> String.class).limit(methodArgs.length).toArray(Class<?>[]::new);
+    Method method = FilesCreateTest.class.getDeclaredMethod(methodName, methodArgumentTypes);
+    method.setAccessible(true);
+    if (!isStatic(method.getModifiers()) || method.getReturnType() != void.class) {
+      throw new NoSuchMethodException(String.format("Target method %s.%s must be a static void method",
+          FilesCreateTest.class.getName(), methodName));
+    }
+    return method;
+  }
+}

--- a/tools/src/test/resources/logback-test.xml
+++ b/tools/src/test/resources/logback-test.xml
@@ -18,10 +18,11 @@
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%-5level [%thread] %logger{15} : %msg%n</pattern>
+      <pattern>%date{HH:mm:ss.SSS} %-5level %mdc{PID} [%thread] %logger{15} : %msg%n</pattern>
     </encoder>
   </appender>
 
+  <logger name="org.terracotta.utilities.concurrent.InterprocessCyclicBarrier" level="INFO"/>
   <logger name="org.terracotta.utilities.io.Files" level="INFO"/>
   <logger name="org.terracotta.utilities.io.FilesTestBase" level="INFO"/>
   <logger name="org.terracotta.utilities.io.FilesCopyTest" level="INFO"/>


### PR DESCRIPTION
This commit adds a Files.createFile method that handles the
AccessDeniedException thrown from java.nio.file.Files.createFile
when the target file is just marked for deletion and not yet
deleted (Windows).

To support testing of this method, InterprocessCyclicBarrier is added
to permit test coordination among Java processes.

This commit resolves #50.