### PR TITLE
PortManager updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>org.terracotta</groupId>
   <artifactId>terracotta-utilities-parent</artifactId>
-  <version>0.0-SNAPSHOT</version>
+  <version>0.0.13-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Terracotta Utilities Parent</name>
   <description>Parent POM for the Terracotta Utilities artifacts</description>

--- a/port-chooser/pom.xml
+++ b/port-chooser/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>terracotta-utilities-parent</artifactId>
-    <version>0.0-SNAPSHOT</version>
+    <version>0.0.13-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/port-chooser/src/main/java/org/terracotta/utilities/test/net/PortManager.java
+++ b/port-chooser/src/main/java/org/terracotta/utilities/test/net/PortManager.java
@@ -19,6 +19,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terracotta.utilities.test.net.PortManager.PortRef.CloseOption;
 
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
@@ -41,15 +42,17 @@ import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.IntConsumer;
+import java.util.function.BiConsumer;
 import java.util.function.IntUnaryOperator;
 
 import static java.lang.Integer.toHexString;
@@ -57,6 +60,7 @@ import static java.lang.System.identityHashCode;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
+import static org.terracotta.utilities.test.net.PortManager.PortRef.CloseOption.NO_RELEASE_CHECK;
 
 /**
  * Manages TCP port reservation/de-reservation while attempting to avoid
@@ -452,7 +456,7 @@ public class PortManager {
     return null;
   }
 
-  private synchronized void release(int port) {
+  private synchronized void release(int port, Set<CloseOption> options) {
     portMap.clear(port);
     allocatedPorts.remove(port);
     LOGGER.info("Port {} released (JVM-level)", port);
@@ -507,8 +511,13 @@ public class PortManager {
    * if not.  This check is <b>not</b> performed if {@value #DISABLE_PORT_RELEASE_CHECK_PROPERTY}
    * is set to {@code true}.
    * @param port the port to check
+   * @param options the set of {@link CloseOption} members used to influence the release check
    */
-  private void diagnosticReleaseCheck(int port) {
+  private void diagnosticReleaseCheck(int port, Set<CloseOption> options) {
+    if (options.contains(NO_RELEASE_CHECK)) {
+      // Silently return
+      return;
+    }
     if (Boolean.getBoolean(DISABLE_PORT_RELEASE_CHECK_PROPERTY)) {
       LOGGER.info("Port {} release check for disabled by {}=true", port, DISABLE_PORT_RELEASE_CHECK_PROPERTY);
       return;
@@ -598,7 +607,7 @@ public class PortManager {
    */
   private static class AllocatedPort extends WeakReference<PortRef> {
     private final int port;
-    private final AtomicReference<IntConsumer> closer;
+    private final AtomicReference<BiConsumer<Integer, Set<CloseOption>>> closer;
     private AllocatedPort(PortRef referent, ReferenceQueue<? super PortRef> q) {
       super(referent, q);
       this.port = referent.port();
@@ -607,7 +616,8 @@ public class PortManager {
 
     private void release() {
       try {
-        Optional.ofNullable(this.closer.get()).ifPresent(action -> action.accept(port));
+        Optional.ofNullable(this.closer.get())
+            .ifPresent(action -> action.accept(port, EnumSet.noneOf(CloseOption.class)));
       } catch (Exception ignored) {
       }
     }
@@ -619,7 +629,8 @@ public class PortManager {
    */
   public static class PortRef implements AutoCloseable {
     private final int port;
-    private final AtomicReference<IntConsumer> closers = new AtomicReference<>(port -> {});
+    private final AtomicReference<BiConsumer<Integer, Set<CloseOption>>> closers =
+        new AtomicReference<>((port, options) -> {});
     private final AtomicBoolean closed = new AtomicBoolean();
 
     private PortRef(int port) {
@@ -632,7 +643,7 @@ public class PortManager {
      * number being closed.
      * @param action the action to take to close this {@code PortRef} instance
      */
-    void onClose(IntConsumer action) {
+    void onClose(BiConsumer<Integer, Set<CloseOption>> action) {
       closers.accumulateAndGet(action, PortManager::combine);
     }
 
@@ -640,7 +651,7 @@ public class PortManager {
      * Gets the "closers" {@code AtomicReference} for use during weak-reference release.
      * @return the {@code AtomicReference} instance to call for closing this {@code PortRef}
      */
-    private AtomicReference<IntConsumer> closers() {
+    private AtomicReference<BiConsumer<Integer, Set<CloseOption>>> closers() {
       return closers;
     }
 
@@ -665,33 +676,54 @@ public class PortManager {
      */
     @Override
     public void close() {
+      this.close(EnumSet.noneOf(CloseOption.class));
+    }
+
+    /**
+     * Closes this {@code PortRef} using the options provided.
+     * @param options the set of {@link CloseOption}s to apply to this close call; may be empty but not {@code null}
+     */
+    public void close(Set<CloseOption> options) {
+      requireNonNull(options, "options");
       if (closed.compareAndSet(false, true)) {
-        Optional.ofNullable(closers.getAndSet(null)).ifPresent(action -> action.accept(port));
+        Optional.ofNullable(closers.getAndSet(null)).ifPresent(action -> action.accept(port, options));
       }
+    }
+
+    /**
+     * Options that may be used with {@link #close(Set)}.
+     */
+    public enum CloseOption {
+      /**
+       * Indicates that no busy check should be performed when closing the {@code PortRef} and
+       * releasing a port. This option should be used only when it is known that the port has not
+       * been used and cannot be busy.
+       */
+      NO_RELEASE_CHECK
     }
   }
 
   /**
-   * Combines {@code IntConsumer} instances to run in reverse sequence.
-   * @param a the second {@code IntConsumer} to run
-   * @param b the first {@code IntConsumer} to run
-   * @return a new {@code IntConsumer} running {@code b} then {@code a}
+   * Combines {@code BiConsumer} instances to run in reverse sequence.
+   * @param a the second {@code BiConsumer} to run
+   * @param b the first {@code BiConsumer} to run
+   * @return a new {@code BiConsumer} running {@code b} then {@code a}
    */
-  private static IntConsumer combine(IntConsumer a, IntConsumer b) {
+  private static <T, U> BiConsumer<T, U> combine(BiConsumer<T, U> a, BiConsumer<T, U> b) {
     requireNonNull(a, "a");
     requireNonNull(b, "b");
-    return i -> {
+    return (t, u) -> {
       try {
-        b.accept(i);
+        b.accept(t, u);
       } catch (Throwable t1) {
         try {
-          a.accept(i);
+          a.accept(t, u);
         } catch (Throwable t2) {
           t1.addSuppressed(t2);
         }
         throw t1;
       }
-      a.accept(i);
+      a.accept(t, u);
     };
   }
 

--- a/port-chooser/src/main/java/org/terracotta/utilities/test/net/SystemLevelLocker.java
+++ b/port-chooser/src/main/java/org/terracotta/utilities/test/net/SystemLevelLocker.java
@@ -66,7 +66,7 @@ class SystemLevelLocker {
       lockFilePath = CommonFiles.createCommonAppFile(RELATIVE_LOCK_FILE_PATH);
 
       /*
-       * If the file returned is an existing file, it _should_ be readable and writable
+       * If the file returned is an existing file, it _should_ be readable and writable,
        * but we need to check ...
        */
       if (!Files.isReadable(lockFilePath)) {
@@ -99,7 +99,7 @@ class SystemLevelLocker {
       FileLock fileLock = openChannel.tryLock(port, 1, false);
       if (fileLock != null) {
         outstandingLocks++;
-        portRef.onClose(p -> {
+        portRef.onClose((p, o) -> {
           assert p == port;
           release(p, fileLock);
         });
@@ -143,7 +143,7 @@ class SystemLevelLocker {
   }
 
   /**
-   * Closes {@link #openChannel} if there are not outstanding locks.
+   * Closes {@link #openChannel} if there are no outstanding locks.
    */
   private void closeChannelIfUnused() {
     if (openChannel != null && outstandingLocks == 0) {

--- a/test-tools/pom.xml
+++ b/test-tools/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>terracotta-utilities-parent</artifactId>
-    <version>0.0-SNAPSHOT</version>
+    <version>0.0.13-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>terracotta-utilities-parent</artifactId>
-    <version>0.0-SNAPSHOT</version>
+    <version>0.0.13-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 


### PR DESCRIPTION
This commit stream includes the following items:

* Correction to disabling the port release busy check -- corrects #54 
* Add options to PortRef.close to permit programmatically bypassing the port release busy check
* Changing the snapshot version from a 2-position (`0.0-SNAPSHOT`) to a 3-position (`0.0.13-SNAPSHOT`) value 

`PortRef.close(Set<CloseOption>)` is added to support cases where an unusual port allocation scheme is needed -- as is used in Galvan `org.terracotta.testing.master.AbstractHarnessEntry.chooseRandomPortRange` in which ports may be allocated but never used.

The snapshot version is changed to permit proper use of range-based versioning -- seems that both Maven and Gradle consider `0.0-SNAPSHOT` to be _less than_ `0.0.12`. 