### PR TITLE
Use version range for logging components

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,8 +38,10 @@
     <java.version>1.8</java.version>
     <maven.version>3.6.3</maven.version>
     <spotbugs-annotations.version>4.0.2</spotbugs-annotations.version>
-    <slf4j.version>1.7.25</slf4j.version>
-    <logback.version>1.2.3</logback.version>
+    <slf4j.base.version>1.7.32</slf4j.base.version>
+    <slf4j.range.version>[${slf4j.base.version},1.7.9999)</slf4j.range.version>
+    <logback.base.version>1.2.11</logback.base.version>
+    <logback.range.version>[${logback.base.version},1.2.9999)</logback.range.version>
     <hamcrest.version>2.2</hamcrest.version>
     <mokito.version>3.3.3</mokito.version>
     <junit.version>4.12</junit.version>
@@ -66,13 +68,19 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>${slf4j.version}</version>
+        <version>${slf4j.range.version}</version>
       </dependency>
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
-        <version>${logback.version}</version>
+        <version>${logback.range.version}</version>
         <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>
@@ -252,26 +260,19 @@
       </plugin>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <dependencyConvergence>
-                  <uniqueVersions>true</uniqueVersions>
-                </dependencyConvergence>
-                <requireJavaVersion>
-                  <version>[${java.version},)</version>
-                </requireJavaVersion>
-                <requireMavenVersion>
-                  <version>[${maven.version},)</version>
-                </requireMavenVersion>
-              </rules>
-            </configuration>
-          </execution>
-        </executions>
+        <configuration>
+          <rules>
+            <dependencyConvergence>
+              <uniqueVersions>true</uniqueVersions>
+            </dependencyConvergence>
+            <requireJavaVersion>
+              <version>[${java.version},)</version>
+            </requireJavaVersion>
+            <requireMavenVersion>
+              <version>[${maven.version},)</version>
+            </requireMavenVersion>
+          </rules>
+        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-source-plugin</artifactId>

--- a/test-tools/pom.xml
+++ b/test-tools/pom.xml
@@ -52,14 +52,14 @@
       <!-- Dependency needed when ConsoleAppenderCapture is used. -->
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
-      <version>${logback.version}</version>
+      <version>${logback.range.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <!-- Dependency needed when ConsoleAppenderCapture is used. -->
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>${logback.version}</version>
+      <version>${logback.range.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/test-tools/src/test/java/org/terracotta/utilities/test/logging/ConsoleAppenderCaptureNoConsoleTest.java
+++ b/test-tools/src/test/java/org/terracotta/utilities/test/logging/ConsoleAppenderCaptureNoConsoleTest.java
@@ -20,6 +20,7 @@ import ch.qos.logback.core.ConsoleAppender;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.slf4j.ILoggerFactory;
 import org.slf4j.LoggerFactory;
 
 import static java.util.Spliterator.ORDERED;
@@ -46,7 +47,10 @@ public class ConsoleAppenderCaptureNoConsoleTest {
    */
   @BeforeClass
   public static void preCondition() {
-    boolean hasConsoleAppender = ((LoggerContext)LoggerFactory.getILoggerFactory()).getLoggerList().stream()
+    ILoggerFactory iLoggerFactory = LoggerFactory.getILoggerFactory();
+    assertThat("iLoggerFactory is not a LoggerContext; examine 'stderr' for messages from SLF4J",
+        iLoggerFactory, is(instanceOf(LoggerContext.class)));
+    boolean hasConsoleAppender = ((LoggerContext)iLoggerFactory).getLoggerList().stream()
         .flatMap(l -> stream(spliteratorUnknownSize(l.iteratorForAppenders(), ORDERED), false))
         .anyMatch(a -> (a instanceof ConsoleAppender));
     assumeFalse("Suppressed -- ConsoleAppender present", hasConsoleAppender);

--- a/test-tools/src/test/java/org/terracotta/utilities/test/logging/ConsoleAppenderCaptureTest.java
+++ b/test-tools/src/test/java/org/terracotta/utilities/test/logging/ConsoleAppenderCaptureTest.java
@@ -26,6 +26,7 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
+import org.slf4j.ILoggerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -58,6 +59,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
@@ -78,7 +80,10 @@ public class ConsoleAppenderCaptureTest {
    */
   @BeforeClass
   public static void configureLogger() {
-    LoggerContext loggerContext = (LoggerContext)LoggerFactory.getILoggerFactory();
+    ILoggerFactory iLoggerFactory = LoggerFactory.getILoggerFactory();
+    assertThat("iLoggerFactory is not a LoggerContext; examine 'stderr' for messages from SLF4J",
+        iLoggerFactory, is(instanceOf(LoggerContext.class)));
+    LoggerContext loggerContext = (LoggerContext)iLoggerFactory;
 
     /*
      * Determine if a ConsoleAppender fpr STDOUT is already present in the ROOT logger.  (Tests


### PR DESCRIPTION
This commit shifts to the use of version ranges for SLF4J and logback.
SLF4J is capped at 1.7.9999 to avoid picking up 1.8.0-betaX releases
which will not work with released versions of Logback before 1.3.x.
The minimum versions of Logback is 1.2.11 which requires a minumum
version of SLF4J of 1.7.32.

While developing this update, it was observed that the SLF4J version
must "align" with the Logback version for Logback to be properly
initialized.  With this observation, tests for ConsoleAppenderCapture
are changed to terminate with a more informative assertion to avoid
an obscure test failure.

The configuration for the enforcer plugin is lifted out of an
execution configuration to permit its use as a top-level task.