### PR TITLE
Test & dependency (exclusion) update

### DIFF
--- a/port-chooser/pom.xml
+++ b/port-chooser/pom.xml
@@ -47,6 +47,12 @@
       <groupId>org.terracotta</groupId>
       <artifactId>terracotta-utilities-tools</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.terracotta</groupId>

--- a/port-chooser/src/test/java/org/terracotta/utilities/test/net/PortManagerTest.java
+++ b/port-chooser/src/test/java/org/terracotta/utilities/test/net/PortManagerTest.java
@@ -194,12 +194,12 @@ public class PortManagerTest {
     PortManager.PortRef portRef = portManager.reservePort();
     int port = portRef.port();
     try (ServerSocket ignored = new ServerSocket(port)) {
-      portRef.close();
+      portRef.close(EnumSet.of(PortManager.PortRef.CloseOption.NO_RELEASE_CHECK));
       assertThat(portManager.reserve(port), is(Optional.empty()));
     }
     Optional<PortManager.PortRef> optional = portManager.reserve(port);
     assertTrue(optional.isPresent());
-    optional.get().close();
+    optional.get().close(EnumSet.of(PortManager.PortRef.CloseOption.NO_RELEASE_CHECK));
   }
 
   @Test


### PR DESCRIPTION
This commit stream contains two items:

* Apply exclusion to correct dependency convergence failure

  Module terracotta-utilities-port-chooser fails dependency convergence
verification because dependency convergence analysis fixes the version
of SLF4J used in terracotta-utilities-tools at the minimum version of
the range even though the dependency actually resolves the latest
available in the range.  The terracotta-utilities-port-chooser POM is
changed to exclude the SLF4J transitive dependency of
terracotta-utilities-tools in deference to the direct dependency.

* Avoid testExistingServerPort test timeout

  PortManagerTest.testExistingServerPort times out when the test
environment has many open ports -- the PortRef release port busy
checking time is sensitive to the number of open ports.  Use of the
port busy check for the failing test is unnecessary and is suppressed
by using the NO_RELEASE_CHECK close.