### PR TITLE
PortManger updates

### DIFF
--- a/.github/workflows/ci-javadoc.yaml
+++ b/.github/workflows/ci-javadoc.yaml
@@ -15,10 +15,8 @@ jobs:
     # uncomment to disable this job
     #if: ${{ false }}
     name: Build Javadoc
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
-      - name: Install fontconfig
-        run: sudo apt-get install -y fontconfig
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install Java
@@ -27,4 +25,4 @@ jobs:
           java-version: 11
           distribution: zulu
       - name: Build Javadoc with Maven
-        run: ./mvnw install javadoc:javadoc -V -B -DskipToolchain -DskipTests -Djava.version=11
+        run: ./mvnw package -V -B -DskipToolchain -DskipTests "-Djava.version=11"

--- a/.github/workflows/ci-javadoc.yaml
+++ b/.github/workflows/ci-javadoc.yaml
@@ -1,0 +1,30 @@
+name: CI - Javadoc
+on:
+  # allow to manually trigger a build through the Actions tab
+  workflow_dispatch:
+  # trigger build on PR
+  pull_request:
+  # trigger build when a branch is pushed
+  push:
+    # put here a list of branches like master, release/x.y, or any branch name activated for building. This also applies to forks.
+    branches:
+      - master
+      - ga # required at the moment until this PR is merged, to verify it works in my fork. Can be removed after once GA build integration is finished.
+jobs:
+  javadoc:
+    # uncomment to disable this job
+    #if: ${{ false }}
+    name: Build Javadoc
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install fontconfig
+        run: sudo apt-get install -y fontconfig
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Java
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: zulu
+      - name: Build Javadoc with Maven
+        run: ./mvnw install javadoc:javadoc -V -B -DskipToolchain -DskipTests -Djava.version=11

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
           java-version: ${{matrix.java}}
           distribution: ${{matrix.distribution}}
       - name: Test with Maven
-        run: ./mvnw clean verify -V -B "-Dmaven.artifact.threads=64" "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -DskipToolchain "-Djava.version=${{matrix.java}}" -Dmaven.javadoc.skip
+        run: ./mvnw clean verify -V -B "-Dmaven.artifact.threads=64" "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -DskipToolchain "-Djava.version=${{matrix.java}}" "-Dmaven.javadoc.skip"
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v2
@@ -79,7 +79,7 @@ jobs:
         # This issue is impacting any code computing paths based on "user.home"
         # A widely known workaround is then to pass it manually.
         # Details: https://bugs.openjdk.java.net/browse/JDK-8193433
-        run: export MAVEN_OPTS=-Duser.home=$HOME && export JAVA_OPTS=-Duser.home=$HOME && ./mvnw clean verify -V -B "-Dmaven.artifact.threads=64" "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -DskipToolchain "-Djava.version=${{matrix.java}}" -Dmaven.javadoc.skip
+        run: export MAVEN_OPTS=-Duser.home=$HOME && export JAVA_OPTS=-Duser.home=$HOME && ./mvnw clean verify -V -B "-Dmaven.artifact.threads=64" "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -DskipToolchain "-Djava.version=${{matrix.java}}" "-Dmaven.javadoc.skip"
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v2
@@ -109,7 +109,7 @@ jobs:
           java-version: ${{matrix.java}}
           distribution: ${{matrix.distribution}}
       - name: Test with Maven
-        run: ./mvnw clean verify -V -B "-Dmaven.artifact.threads=64" "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -DskipToolchain "-Djava.version=${{matrix.java}}" -Dmaven.javadoc.skip
+        run: ./mvnw clean verify -V -B "-Dmaven.artifact.threads=64" "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -DskipToolchain "-Djava.version=${{matrix.java}}" "-Dmaven.javadoc.skip"
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
           java-version: ${{matrix.java}}
           distribution: ${{matrix.distribution}}
       - name: Test with Maven
-        run: ./mvnw clean verify -V -B "-Dmaven.artifact.threads=64" "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -DskipToolchain "-Djava.version=${{matrix.java}}"
+        run: ./mvnw clean verify -V -B "-Dmaven.artifact.threads=64" "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -DskipToolchain "-Djava.version=${{matrix.java}}" -Dmaven.javadoc.skip
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v2
@@ -79,7 +79,7 @@ jobs:
         # This issue is impacting any code computing paths based on "user.home"
         # A widely known workaround is then to pass it manually.
         # Details: https://bugs.openjdk.java.net/browse/JDK-8193433
-        run: export MAVEN_OPTS=-Duser.home=$HOME && export JAVA_OPTS=-Duser.home=$HOME && ./mvnw clean verify -V -B "-Dmaven.artifact.threads=64" "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -DskipToolchain "-Djava.version=${{matrix.java}}"
+        run: export MAVEN_OPTS=-Duser.home=$HOME && export JAVA_OPTS=-Duser.home=$HOME && ./mvnw clean verify -V -B "-Dmaven.artifact.threads=64" "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -DskipToolchain "-Djava.version=${{matrix.java}}" -Dmaven.javadoc.skip
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v2
@@ -109,7 +109,7 @@ jobs:
           java-version: ${{matrix.java}}
           distribution: ${{matrix.distribution}}
       - name: Test with Maven
-        run: ./mvnw clean verify -V -B "-Dmaven.artifact.threads=64" "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -DskipToolchain "-Djava.version=${{matrix.java}}"
+        run: ./mvnw clean verify -V -B "-Dmaven.artifact.threads=64" "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -DskipToolchain "-Djava.version=${{matrix.java}}" -Dmaven.javadoc.skip
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v2

--- a/README.md
+++ b/README.md
@@ -24,3 +24,9 @@ This project operates under the following constraints:
     If an artifact on which `test-tools` relies makes a breaking change,
     introduce new artifact containing the breaking components -- not a 
     new version of the `test-tools` artifact. 
+
+## Notes
+
+* While the project is currently designed to produce artifacts operable under Java 8, the complete Javadoc
+  will not be produced unless a Java 11 runtime is used during the build.  (The plugin used to generate
+  diagrams included in the Javadoc requires running under Java 11.)

--- a/pom.xml
+++ b/pom.xml
@@ -140,10 +140,13 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>3.2.0</version>
           <configuration>
+            <detectJavaApiLink>false</detectJavaApiLink>
+            <doclint>-accessibility</doclint><!-- Avoid complaints about table@summary -->
             <failOnError>false</failOnError>
             <failOnWarnings>false</failOnWarnings>
             <quiet>true</quiet>
             <author>false</author>
+            <javadocDirectory>${project.build.directory}/generated-sources/javadoc</javadocDirectory>
           </configuration>
         </plugin>
         <plugin>
@@ -335,6 +338,32 @@
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
       </plugin>
+
+      <plugin>
+        <!-- com.github.funthomas424242:plantuml-maven-plugin requires Java 11+ -->
+        <groupId>com.github.funthomas424242</groupId>
+        <artifactId>plantuml-maven-plugin</artifactId>
+        <version>1.5.2</version>
+        <configuration>
+          <truncatePattern>src/main/*</truncatePattern>
+          <sourceFiles>
+            <directory>${basedir}</directory>
+            <includes>
+              <include>src/main/java/**/*.java</include>
+            </includes>
+          </sourceFiles>
+          <outputDirectory>${project.build.directory}/generated-sources/javadoc</outputDirectory>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>net.sourceforge.plantuml</groupId>
+            <artifactId>plantuml</artifactId>
+            <version>1.2022.6</version>
+            <scope>runtime</scope>
+          </dependency>
+        </dependencies>
+      </plugin>
+
     </plugins>
   </build>
 

--- a/port-chooser/pom.xml
+++ b/port-chooser/pom.xml
@@ -91,6 +91,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <!-- Most tests should run with DISABLE_PORT_RELEASE_CHECK false or unset -->
+          <excludedEnvironmentVariables>DISABLE_PORT_RELEASE_CHECK</excludedEnvironmentVariables>
+        </configuration>
         <executions>
           <execution>
             <!-- Repeat tests using IPv4 preference -->
@@ -115,7 +119,7 @@
             </goals>
           </execution>
           <execution>
-            <!-- Repeat tests using IPv4 preference - single test ouf of long-running suite -->
+            <!-- Repeat tests using IPv4 preference - single test of long-running suite -->
             <id>IPv4_A</id>
             <configuration>
               <systemPropertyVariables>
@@ -124,6 +128,21 @@
               </systemPropertyVariables>
               <test>org.terracotta.utilities.test.net.PortManagerTest#testReleaseCheckEnabled</test>
               <reportNameSuffix>IPv4_A</reportNameSuffix>
+            </configuration>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+          </execution>
+          <execution>
+            <!-- Single test for DISABLE_PORT_RELEASE_CHECK=true -->
+            <id>PortCheckDisabled</id>
+            <configuration>
+              <environmentVariables>
+                <DISABLE_PORT_RELEASE_CHECK>true</DISABLE_PORT_RELEASE_CHECK>
+              </environmentVariables>
+              <test>org.terracotta.utilities.test.net.PortManagerTest#testReleaseCheckDisabledEnvironment</test>
+              <reportNameSuffix>PortCheckDisabled</reportNameSuffix>
             </configuration>
             <phase>test</phase>
             <goals>

--- a/port-chooser/pom.xml
+++ b/port-chooser/pom.xml
@@ -154,6 +154,34 @@
     </plugins>
   </build>
 
+  <profiles>
+    <profile>
+      <!-- PlantUML diagram generation for javadoc requires Java 11+ -->
+      <id>plantuml-diagrams</id>
+      <activation>
+        <jdk>[11,)</jdk>
+        <property><name>!maven.javadoc.skip</name></property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.github.funthomas424242</groupId>
+            <artifactId>plantuml-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>plantuml</id>
+                <goals>
+                  <goal>generate</goal>
+                </goals>
+                <phase>generate-sources</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
   <scm>
     <connection>scm:git:https://github.com/terracotta-oss/terracotta-utilities.git</connection>
     <developerConnection>scm:git:git@github.com:terracotta-oss/terracotta-utilities.git</developerConnection>

--- a/port-chooser/src/main/java/org/terracotta/utilities/test/net/NetStat.java
+++ b/port-chooser/src/main/java/org/terracotta/utilities/test/net/NetStat.java
@@ -1232,7 +1232,7 @@ public class NetStat {
      * The following diagram shows the usual TCP state transitions.  For a discussion of this diagram,
      * see <i>RFC-793 Transmission Control Protocol</i> and
      * <i>TCP/IP Illustrated, Volume 1, 1ed: The Protocols</i> by W. Richard Stevens.
-     * <table summary="TCP State Diagram &amp; Legend">
+     * <table>
      *   <tbody>
      *     <tr>
      *       <td><img src="doc-files/tcp_state_diagram.png" alt="TCP State Diagram"></td>

--- a/port-chooser/src/main/java/org/terracotta/utilities/test/net/PortManager.java
+++ b/port-chooser/src/main/java/org/terracotta/utilities/test/net/PortManager.java
@@ -563,6 +563,7 @@ public class PortManager {
         disableCheck = true;
       } else {
         List<NetStat.BusyPort> collisions = portInfo.stream()
+            .filter(p -> p.state() != NetStat.BusyPort.TcpState.TIME_WAIT)    // Exclude TIME_WAIT
             .filter(p -> p.localEndpoint().getPort() == port)
             .collect(toList());
         if (!collisions.isEmpty()) {

--- a/port-chooser/src/test/java/org/terracotta/utilities/test/net/PortManagerTest.java
+++ b/port-chooser/src/test/java/org/terracotta/utilities/test/net/PortManagerTest.java
@@ -318,6 +318,10 @@ public class PortManagerTest {
     // This test requires a properly functioning 'sudo --non-interactive -- lsof ...' on Linux
     assumeTrue("'sudo --non-interactive -- lsof -iTCP not available", TestSupport.sudoLsofWorks());
 
+    // This test MUST be run when PortManager.DISABLE_PORT_RELEASE_CHECK_ENV_VARIABLE is false or not specified
+    assertFalse(PortManager.DISABLE_PORT_RELEASE_CHECK_ENV_VARIABLE + " environment variable must be false or not specified",
+        Boolean.parseBoolean(System.getenv(PortManager.DISABLE_PORT_RELEASE_CHECK_ENV_VARIABLE)));
+
     try (ListAppender appender = new ListAppender(LoggerFactory.getLogger(PortManager.class), "WARN")) {
       PortManager.PortRef portRef = portManager.reservePort();
       int port = portRef.port();
@@ -342,6 +346,10 @@ public class PortManagerTest {
   @SuppressWarnings("try")
   @Test
   public void testReleaseCheckDisabled() throws IOException {
+    // This test MUST be run when PortManager.DISABLE_PORT_RELEASE_CHECK_ENV_VARIABLE is false or not specified
+    assertFalse(PortManager.DISABLE_PORT_RELEASE_CHECK_ENV_VARIABLE + " environment variable must be false or not specified",
+        Boolean.parseBoolean(System.getenv(PortManager.DISABLE_PORT_RELEASE_CHECK_ENV_VARIABLE)));
+
     try (ListAppender appender = new ListAppender(LoggerFactory.getLogger(PortManager.class), "WARN")) {
       PortManager.PortRef portRef = portManager.reservePort();
       int port = portRef.port();
@@ -356,6 +364,26 @@ public class PortManagerTest {
             System.setProperty(PortManager.DISABLE_PORT_RELEASE_CHECK_PROPERTY, portReleaseCheck);
           }
         }
+        assertThat(appender.events(), not(hasItem(allOf(
+            hasProperty("level", equalTo(Level.ERROR)),
+            hasProperty("loggerName", equalTo(PortManager.class.getName())),
+            hasProperty("formattedMessage", is(stringContainsInOrder("Port " + port, "state='LISTEN'")))
+        ))));
+      }
+    }
+  }
+
+  @SuppressWarnings("try")
+  @Test
+  public void testReleaseCheckDisabledEnvironment() throws IOException {
+    assumeTrue("Skipped unless " + PortManager.DISABLE_PORT_RELEASE_CHECK_ENV_VARIABLE + " environment variable is true",
+        Boolean.parseBoolean(System.getenv(PortManager.DISABLE_PORT_RELEASE_CHECK_ENV_VARIABLE)));
+
+    try (ListAppender appender = new ListAppender(LoggerFactory.getLogger(PortManager.class), "WARN")) {
+      PortManager.PortRef portRef = portManager.reservePort();
+      int port = portRef.port();
+      try (ServerSocket ignored = new ServerSocket(port)) {
+        portRef.close();
         assertThat(appender.events(), not(hasItem(allOf(
             hasProperty("level", equalTo(Level.ERROR)),
             hasProperty("loggerName", equalTo(PortManager.class.getName())),

--- a/tools/src/main/java/org/terracotta/utilities/io/Files.java
+++ b/tools/src/main/java/org/terracotta/utilities/io/Files.java
@@ -672,7 +672,7 @@ public final class Files {
    * interference from system tasks.
    * <p>
    * The following options are supported:
-   * <table border=1 cellpadding=5 summary="">
+   * <table border=1>
    * <tr> <th>Option</th> <th>Description</th> </tr>
    * <tr>
    *   <td>{@link StandardCopyOption#REPLACE_EXISTING REPLACE_EXISTING}</td>


### PR DESCRIPTION
This commit stream includesthe following:

* Add DISABLE_PORT_RELEASE_CHECK environment variable

  This commit enables the use of the 'DISABLE_PORT_RELEASE_CHECK' environment variable to, when set to 'true', disable the port release check performed by PortManager.

* Treat TIME_WAIT as normal TCP connection status

  This commit removes TCP connections in a TIME_WAIT status from the results displayed by the port release check performed by PortManager.

  This commit also adds Javadoc for NetStat.BusyPort.TcpState describing the possible TCP connection state transitions. The diagrams in the documentation require Java 11+ to generate and, for a _complete_ build, now requires Java 11.  (Java 8 may continue to be used but the result will lack the diagrams.)

I'll be working with @akomakom to adjust the releaser to use Java 11.