### PR TITLE
Separate javadoc build, preinstall fontconfig for PlantUML

### DIFF
--- a/.github/workflows/ci-javadoc.yaml
+++ b/.github/workflows/ci-javadoc.yaml
@@ -1,0 +1,30 @@
+name: CI - Javadoc
+on:
+  # allow to manually trigger a build through the Actions tab
+  workflow_dispatch:
+  # trigger build on PR
+  pull_request:
+  # trigger build when a branch is pushed
+  push:
+    # put here a list of branches like master, release/x.y, or any branch name activated for building. This also applies to forks.
+    branches:
+      - master
+      - ga # required at the moment until this PR is merged, to verify it works in my fork. Can be removed after once GA build integration is finished.
+jobs:
+  javadoc:
+    # uncomment to disable this job
+    #if: ${{ false }}
+    name: Build Javadoc
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install fontconfig
+        run: sudo apt-get install -y fontconfig
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Java
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: zulu
+      - name: Build Javadoc with Maven
+        run: ./mvnw install javadoc:javadoc -V -B -DskipToolchain -DskipTests -Djava.version=11

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
           java-version: ${{matrix.java}}
           distribution: ${{matrix.distribution}}
       - name: Test with Maven
-        run: ./mvnw clean verify -V -B "-Dmaven.artifact.threads=64" "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -DskipToolchain "-Djava.version=${{matrix.java}}" -Dmaven.javadoc.skip
+        run: ./mvnw clean verify -V -B "-Dmaven.artifact.threads=64" "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -DskipToolchain "-Djava.version=${{matrix.java}}" "-Dmaven.javadoc.skip"
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v2
@@ -79,7 +79,7 @@ jobs:
         # This issue is impacting any code computing paths based on "user.home"
         # A widely known workaround is then to pass it manually.
         # Details: https://bugs.openjdk.java.net/browse/JDK-8193433
-        run: export MAVEN_OPTS=-Duser.home=$HOME && export JAVA_OPTS=-Duser.home=$HOME && ./mvnw clean verify -V -B "-Dmaven.artifact.threads=64" "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -DskipToolchain "-Djava.version=${{matrix.java}}" -Dmaven.javadoc.skip
+        run: export MAVEN_OPTS=-Duser.home=$HOME && export JAVA_OPTS=-Duser.home=$HOME && ./mvnw clean verify -V -B "-Dmaven.artifact.threads=64" "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -DskipToolchain "-Djava.version=${{matrix.java}}" "-Dmaven.javadoc.skip"
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v2
@@ -109,7 +109,7 @@ jobs:
           java-version: ${{matrix.java}}
           distribution: ${{matrix.distribution}}
       - name: Test with Maven
-        run: ./mvnw clean verify -V -B "-Dmaven.artifact.threads=64" "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -DskipToolchain "-Djava.version=${{matrix.java}}" -Dmaven.javadoc.skip
+        run: ./mvnw clean verify -V -B "-Dmaven.artifact.threads=64" "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -DskipToolchain "-Djava.version=${{matrix.java}}" "-Dmaven.javadoc.skip"
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
           java-version: ${{matrix.java}}
           distribution: ${{matrix.distribution}}
       - name: Test with Maven
-        run: ./mvnw clean verify -V -B "-Dmaven.artifact.threads=64" "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -DskipToolchain "-Djava.version=${{matrix.java}}"
+        run: ./mvnw clean verify -V -B "-Dmaven.artifact.threads=64" "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -DskipToolchain "-Djava.version=${{matrix.java}}" -Dmaven.javadoc.skip
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v2
@@ -79,7 +79,7 @@ jobs:
         # This issue is impacting any code computing paths based on "user.home"
         # A widely known workaround is then to pass it manually.
         # Details: https://bugs.openjdk.java.net/browse/JDK-8193433
-        run: export MAVEN_OPTS=-Duser.home=$HOME && export JAVA_OPTS=-Duser.home=$HOME && ./mvnw clean verify -V -B "-Dmaven.artifact.threads=64" "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -DskipToolchain "-Djava.version=${{matrix.java}}"
+        run: export MAVEN_OPTS=-Duser.home=$HOME && export JAVA_OPTS=-Duser.home=$HOME && ./mvnw clean verify -V -B "-Dmaven.artifact.threads=64" "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -DskipToolchain "-Djava.version=${{matrix.java}}" -Dmaven.javadoc.skip
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v2
@@ -109,7 +109,7 @@ jobs:
           java-version: ${{matrix.java}}
           distribution: ${{matrix.distribution}}
       - name: Test with Maven
-        run: ./mvnw clean verify -V -B "-Dmaven.artifact.threads=64" "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -DskipToolchain "-Djava.version=${{matrix.java}}"
+        run: ./mvnw clean verify -V -B "-Dmaven.artifact.threads=64" "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -DskipToolchain "-Djava.version=${{matrix.java}}" -Dmaven.javadoc.skip
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Perhaps we should skip checkstyle and stuff in matrix and do all that in the new job?