### PR TITLE
PortManager and NetStat updates

### DIFF
--- a/.github/workflows/ci-javadoc.yaml
+++ b/.github/workflows/ci-javadoc.yaml
@@ -15,10 +15,8 @@ jobs:
     # uncomment to disable this job
     #if: ${{ false }}
     name: Build Javadoc
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
-      - name: Install fontconfig
-        run: sudo apt-get install -y fontconfig
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install Java
@@ -27,4 +25,4 @@ jobs:
           java-version: 11
           distribution: zulu
       - name: Build Javadoc with Maven
-        run: ./mvnw install javadoc:javadoc -V -B -DskipToolchain -DskipTests -Djava.version=11
+        run: ./mvnw package -V -B -DskipToolchain -DskipTests "-Djava.version=11"

--- a/.github/workflows/ci-javadoc.yaml
+++ b/.github/workflows/ci-javadoc.yaml
@@ -1,0 +1,30 @@
+name: CI - Javadoc
+on:
+  # allow to manually trigger a build through the Actions tab
+  workflow_dispatch:
+  # trigger build on PR
+  pull_request:
+  # trigger build when a branch is pushed
+  push:
+    # put here a list of branches like master, release/x.y, or any branch name activated for building. This also applies to forks.
+    branches:
+      - master
+      - ga # required at the moment until this PR is merged, to verify it works in my fork. Can be removed after once GA build integration is finished.
+jobs:
+  javadoc:
+    # uncomment to disable this job
+    #if: ${{ false }}
+    name: Build Javadoc
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install fontconfig
+        run: sudo apt-get install -y fontconfig
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Java
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: zulu
+      - name: Build Javadoc with Maven
+        run: ./mvnw install javadoc:javadoc -V -B -DskipToolchain -DskipTests -Djava.version=11

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
           java-version: ${{matrix.java}}
           distribution: ${{matrix.distribution}}
       - name: Test with Maven
-        run: ./mvnw clean verify -V -B "-Dmaven.artifact.threads=64" "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -DskipToolchain "-Djava.version=${{matrix.java}}" -Dmaven.javadoc.skip
+        run: ./mvnw clean verify -V -B "-Dmaven.artifact.threads=64" "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -DskipToolchain "-Djava.version=${{matrix.java}}" "-Dmaven.javadoc.skip"
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v2
@@ -79,7 +79,7 @@ jobs:
         # This issue is impacting any code computing paths based on "user.home"
         # A widely known workaround is then to pass it manually.
         # Details: https://bugs.openjdk.java.net/browse/JDK-8193433
-        run: export MAVEN_OPTS=-Duser.home=$HOME && export JAVA_OPTS=-Duser.home=$HOME && ./mvnw clean verify -V -B "-Dmaven.artifact.threads=64" "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -DskipToolchain "-Djava.version=${{matrix.java}}" -Dmaven.javadoc.skip
+        run: export MAVEN_OPTS=-Duser.home=$HOME && export JAVA_OPTS=-Duser.home=$HOME && ./mvnw clean verify -V -B "-Dmaven.artifact.threads=64" "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -DskipToolchain "-Djava.version=${{matrix.java}}" "-Dmaven.javadoc.skip"
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v2
@@ -109,7 +109,7 @@ jobs:
           java-version: ${{matrix.java}}
           distribution: ${{matrix.distribution}}
       - name: Test with Maven
-        run: ./mvnw clean verify -V -B "-Dmaven.artifact.threads=64" "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -DskipToolchain "-Djava.version=${{matrix.java}}" -Dmaven.javadoc.skip
+        run: ./mvnw clean verify -V -B "-Dmaven.artifact.threads=64" "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -DskipToolchain "-Djava.version=${{matrix.java}}" "-Dmaven.javadoc.skip"
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
           java-version: ${{matrix.java}}
           distribution: ${{matrix.distribution}}
       - name: Test with Maven
-        run: ./mvnw clean verify -V -B "-Dmaven.artifact.threads=64" "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -DskipToolchain "-Djava.version=${{matrix.java}}"
+        run: ./mvnw clean verify -V -B "-Dmaven.artifact.threads=64" "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -DskipToolchain "-Djava.version=${{matrix.java}}" -Dmaven.javadoc.skip
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v2
@@ -79,7 +79,7 @@ jobs:
         # This issue is impacting any code computing paths based on "user.home"
         # A widely known workaround is then to pass it manually.
         # Details: https://bugs.openjdk.java.net/browse/JDK-8193433
-        run: export MAVEN_OPTS=-Duser.home=$HOME && export JAVA_OPTS=-Duser.home=$HOME && ./mvnw clean verify -V -B "-Dmaven.artifact.threads=64" "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -DskipToolchain "-Djava.version=${{matrix.java}}"
+        run: export MAVEN_OPTS=-Duser.home=$HOME && export JAVA_OPTS=-Duser.home=$HOME && ./mvnw clean verify -V -B "-Dmaven.artifact.threads=64" "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -DskipToolchain "-Djava.version=${{matrix.java}}" -Dmaven.javadoc.skip
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v2
@@ -109,7 +109,7 @@ jobs:
           java-version: ${{matrix.java}}
           distribution: ${{matrix.distribution}}
       - name: Test with Maven
-        run: ./mvnw clean verify -V -B "-Dmaven.artifact.threads=64" "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -DskipToolchain "-Djava.version=${{matrix.java}}"
+        run: ./mvnw clean verify -V -B "-Dmaven.artifact.threads=64" "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -DskipToolchain "-Djava.version=${{matrix.java}}" -Dmaven.javadoc.skip
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,10 +24,10 @@ jobs:
   with-container-root:
     # uncomment to disable this job
     #if: ${{ false }}
-    name: Inside container centos ${{matrix.distribution}}-${{matrix.java}} as root
+    name: Inside container almalinux ${{matrix.distribution}}-${{matrix.java}} as root
     runs-on: ubuntu-latest
     container:
-      image: centos:latest
+      image: almalinux:latest
     strategy:
       matrix:
         java: [ 8, 11 ]
@@ -42,23 +42,25 @@ jobs:
         with:
           java-version: ${{matrix.java}}
           distribution: ${{matrix.distribution}}
+      - name: Install lsof
+        run: yum -y install lsof procps
       - name: Test with Maven
         run: ./mvnw clean verify -V -B "-Dmaven.artifact.threads=64" "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" -DskipToolchain "-Djava.version=${{matrix.java}}" "-Dmaven.javadoc.skip"
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: Test Results (container centos ${{matrix.distribution}}-${{matrix.java}} as root)
+          name: Test Results (container almalinux ${{matrix.distribution}}-${{matrix.java}} as root)
           path: |
             **/target/surefire-reports/**
             **/target/rat.txt
   with-container-user:
     # uncomment to disable this job
     #if: ${{ false }}
-    name: Inside container centos ${{matrix.distribution}}-${{matrix.java}} as user
+    name: Inside container almalinux ${{matrix.distribution}}-${{matrix.java}} as user
     runs-on: ubuntu-latest
     container:
-      image: centos:latest
+      image: almalinux:latest
       options: --user 1001:1001
     strategy:
       matrix:
@@ -84,7 +86,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: Test Results (container centos ${{matrix.distribution}}-${{matrix.java}} as user)
+          name: Test Results (container almalinux ${{matrix.distribution}}-${{matrix.java}} as user)
           path: |
             **/target/surefire-reports/**
             **/target/rat.txt

--- a/README.md
+++ b/README.md
@@ -24,3 +24,9 @@ This project operates under the following constraints:
     If an artifact on which `test-tools` relies makes a breaking change,
     introduce new artifact containing the breaking components -- not a 
     new version of the `test-tools` artifact. 
+
+## Notes
+
+* While the project is currently designed to produce artifacts operable under Java 8, the complete Javadoc
+  will not be produced unless a Java 11 runtime is used during the build.  (The plugin used to generate
+  diagrams included in the Javadoc requires running under Java 11.)

--- a/pom.xml
+++ b/pom.xml
@@ -140,10 +140,13 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>3.2.0</version>
           <configuration>
+            <detectJavaApiLink>false</detectJavaApiLink>
+            <doclint>-accessibility</doclint><!-- Avoid complaints about table@summary -->
             <failOnError>false</failOnError>
             <failOnWarnings>false</failOnWarnings>
             <quiet>true</quiet>
             <author>false</author>
+            <javadocDirectory>${project.build.directory}/generated-sources/javadoc</javadocDirectory>
           </configuration>
         </plugin>
         <plugin>
@@ -335,6 +338,32 @@
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
       </plugin>
+
+      <plugin>
+        <!-- com.github.funthomas424242:plantuml-maven-plugin requires Java 11+ -->
+        <groupId>com.github.funthomas424242</groupId>
+        <artifactId>plantuml-maven-plugin</artifactId>
+        <version>1.5.2</version>
+        <configuration>
+          <truncatePattern>src/main/*</truncatePattern>
+          <sourceFiles>
+            <directory>${basedir}</directory>
+            <includes>
+              <include>src/main/java/**/*.java</include>
+            </includes>
+          </sourceFiles>
+          <outputDirectory>${project.build.directory}/generated-sources/javadoc</outputDirectory>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>net.sourceforge.plantuml</groupId>
+            <artifactId>plantuml</artifactId>
+            <version>1.2022.6</version>
+            <scope>runtime</scope>
+          </dependency>
+        </dependencies>
+      </plugin>
+
     </plugins>
   </build>
 

--- a/port-chooser/pom.xml
+++ b/port-chooser/pom.xml
@@ -160,7 +160,10 @@
       <id>plantuml-diagrams</id>
       <activation>
         <jdk>[11,)</jdk>
-        <property><name>!maven.javadoc.skip</name></property>
+        <property>
+          <name>maven.javadoc.skip</name>
+          <value>!true</value>
+        </property>
       </activation>
       <build>
         <plugins>

--- a/port-chooser/pom.xml
+++ b/port-chooser/pom.xml
@@ -91,6 +91,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <!-- Most tests should run with DISABLE_PORT_RELEASE_CHECK false or unset -->
+          <excludedEnvironmentVariables>DISABLE_PORT_RELEASE_CHECK</excludedEnvironmentVariables>
+        </configuration>
         <executions>
           <execution>
             <!-- Repeat tests using IPv4 preference -->
@@ -115,7 +119,7 @@
             </goals>
           </execution>
           <execution>
-            <!-- Repeat tests using IPv4 preference - single test ouf of long-running suite -->
+            <!-- Repeat tests using IPv4 preference - single test of long-running suite -->
             <id>IPv4_A</id>
             <configuration>
               <systemPropertyVariables>
@@ -124,6 +128,21 @@
               </systemPropertyVariables>
               <test>org.terracotta.utilities.test.net.PortManagerTest#testReleaseCheckEnabled</test>
               <reportNameSuffix>IPv4_A</reportNameSuffix>
+            </configuration>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+          </execution>
+          <execution>
+            <!-- Single test for DISABLE_PORT_RELEASE_CHECK=true -->
+            <id>PortCheckDisabled</id>
+            <configuration>
+              <environmentVariables>
+                <DISABLE_PORT_RELEASE_CHECK>true</DISABLE_PORT_RELEASE_CHECK>
+              </environmentVariables>
+              <test>org.terracotta.utilities.test.net.PortManagerTest#testReleaseCheckDisabledEnvironment</test>
+              <reportNameSuffix>PortCheckDisabled</reportNameSuffix>
             </configuration>
             <phase>test</phase>
             <goals>

--- a/port-chooser/pom.xml
+++ b/port-chooser/pom.xml
@@ -154,6 +154,34 @@
     </plugins>
   </build>
 
+  <profiles>
+    <profile>
+      <!-- PlantUML diagram generation for javadoc requires Java 11+ -->
+      <id>plantuml-diagrams</id>
+      <activation>
+        <jdk>[11,)</jdk>
+        <property><name>!maven.javadoc.skip</name></property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.github.funthomas424242</groupId>
+            <artifactId>plantuml-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>plantuml</id>
+                <goals>
+                  <goal>generate</goal>
+                </goals>
+                <phase>generate-sources</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
   <scm>
     <connection>scm:git:https://github.com/terracotta-oss/terracotta-utilities.git</connection>
     <developerConnection>scm:git:git@github.com:terracotta-oss/terracotta-utilities.git</developerConnection>

--- a/port-chooser/src/main/java/org/terracotta/utilities/test/net/EphemeralPorts.java
+++ b/port-chooser/src/main/java/org/terracotta/utilities/test/net/EphemeralPorts.java
@@ -124,7 +124,7 @@ public class EphemeralPorts {
     private final int upper;
     private final int lower;
 
-    private Range(int lower, int upper) {
+    Range(int lower, int upper) {
       this.lower = lower;
       this.upper = upper;
     }

--- a/port-chooser/src/main/java/org/terracotta/utilities/test/net/NetStat.java
+++ b/port-chooser/src/main/java/org/terracotta/utilities/test/net/NetStat.java
@@ -1232,7 +1232,7 @@ public class NetStat {
      * The following diagram shows the usual TCP state transitions.  For a discussion of this diagram,
      * see <i>RFC-793 Transmission Control Protocol</i> and
      * <i>TCP/IP Illustrated, Volume 1, 1ed: The Protocols</i> by W. Richard Stevens.
-     * <table summary="TCP State Diagram &amp; Legend">
+     * <table>
      *   <tbody>
      *     <tr>
      *       <td><img src="doc-files/tcp_state_diagram.png" alt="TCP State Diagram"></td>

--- a/port-chooser/src/main/java/org/terracotta/utilities/test/net/PortManager.java
+++ b/port-chooser/src/main/java/org/terracotta/utilities/test/net/PortManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright 2020-2022 Terracotta, Inc., a Software AG company.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -563,11 +563,10 @@ public class PortManager {
 
     boolean disableCheck = false;
     try {
-      List<NetStat.BusyPort> portInfo = NetStat.info();
+      List<NetStat.BusyPort> portInfo = NetStat.info(port);
       if (portInfo.isEmpty()) {
-        // An empty list is unusual and not likely to become non-empty on subsequent calls
-        LOGGER.warn("No busy port information obtained to verify release of port {}", port);
-        disableCheck = true;
+        // An empty list for a single port is normal -- the port is no longer in use
+        LOGGER.trace("No busy port information obtained to verify release of port {}", port);
       } else {
         List<NetStat.BusyPort> collisions = portInfo.stream()
             .filter(p -> p.state() != NetStat.BusyPort.TcpState.TIME_WAIT)    // Exclude TIME_WAIT

--- a/port-chooser/src/main/java/org/terracotta/utilities/test/net/PortManager.java
+++ b/port-chooser/src/main/java/org/terracotta/utilities/test/net/PortManager.java
@@ -563,6 +563,7 @@ public class PortManager {
         disableCheck = true;
       } else {
         List<NetStat.BusyPort> collisions = portInfo.stream()
+            .filter(p -> p.state() != NetStat.BusyPort.TcpState.TIME_WAIT)    // Exclude TIME_WAIT
             .filter(p -> p.localEndpoint().getPort() == port)
             .collect(toList());
         if (!collisions.isEmpty()) {

--- a/port-chooser/src/main/java/org/terracotta/utilities/test/net/PortManager.java
+++ b/port-chooser/src/main/java/org/terracotta/utilities/test/net/PortManager.java
@@ -207,6 +207,13 @@ public class PortManager {
     EphemeralPorts.Range range = EphemeralPorts.getRange();
     portMap.set(range.getLower(), range.getUpper() + 1);
 
+    /*
+     * Prevent assignment of any reserved ports on the platform.
+     */
+    for (EphemeralPorts.Range reservedRange : ReservedPorts.getRange()) {
+      portMap.set(reservedRange.getLower(), reservedRange.getUpper() + 1);
+    }
+
     restrictedPorts.or(portMap);
 
     assignablePortCount = MAXIMUM_PORT_NUMBER + 1 - portMap.cardinality();

--- a/port-chooser/src/main/java/org/terracotta/utilities/test/net/ReservedPorts.java
+++ b/port-chooser/src/main/java/org/terracotta/utilities/test/net/ReservedPorts.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2022 Terracotta, Inc., a Software AG company.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.utilities.test.net;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terracotta.utilities.exec.Shell;
+import org.terracotta.utilities.test.runtime.Os;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Identifies reserved ports on a platform.
+ * <p>
+ * More recent releases of Microsoft Windows has the ability, by API or command, to reserve a port
+ * for use by an application.  While typical usage would be to reserve an ephemeral/dynamic port,
+ * reservation is not restricted to these ports so reserved ports need to be avoided in {@link PortManager}
+ * processing.
+ */
+// public for 'main' method
+public final class ReservedPorts {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ReservedPorts.class);
+
+  /**
+   * Gets the list of port ranges considered <i>reserved</i> by the platform.
+   * <p>
+   * This list is calculated for each call to this method; since determining the
+   * list of reserved ports is likely to be expensive, repeated calls should be
+   * avoided.
+   *
+   * @return a list, possibly empty, of reserved port ranges
+   */
+  static List<EphemeralPorts.Range> getRange() {
+    if (Os.isLinux()) { return new Linux().getRanges(); }
+    if (Os.isMac()) { return Collections.emptyList(); }
+    if (Os.isWindows()) { return new Windows().getRanges(); }
+    if (Os.isSolaris()) { return Collections.emptyList(); }
+    if (Os.isAix()) { return Collections.emptyList(); }
+    if (Os.isHpux()) { return Collections.emptyList(); }
+
+    throw new AssertionError("No support for this OS: " + Os.getOsName());
+  }
+
+  /**
+   * Determine the reserved ports on a Linux platform.  The {@code ip_local_reserved_ports} Proc file
+   * contains a comma-separated list of port ranges and individual ports.
+   *
+   * @see <a href="https://github.com/torvalds/linux/blob/master/Documentation/networking/ip-sysctl.rst#ip-variables">/proc/sys/net/ipv4/* Variables : IP Variables</a>
+   */
+  private static class Linux {
+    private static final String SOURCE = "/proc/sys/net/ipv4/ip_local_reserved_ports";
+
+    public List<EphemeralPorts.Range> getRanges() {
+      List<EphemeralPorts.Range> reservedRanges = new ArrayList<>();
+
+      File rangeSource = new File(SOURCE);
+      if (!rangeSource.exists() || !rangeSource.canRead()) {
+        LOGGER.warn("Cannot access \"{}\"; cannot determine reserved ports", SOURCE);
+        return Collections.emptyList();
+      }
+
+      try (BufferedReader reader = new BufferedReader(new InputStreamReader(Files.newInputStream(Paths.get(SOURCE)), StandardCharsets.UTF_8))) {
+        String reservations = reader.readLine();
+        if (reservations == null || reservations.isEmpty()) {
+          LOGGER.debug("No reserved port ranges read from {}", SOURCE);
+          return Collections.emptyList();
+        } else {
+          Pattern rangePattern = Pattern.compile("(\\d+)(?:-(\\d+))?");
+          for (String token : Pattern.compile(",").split(reservations)) {
+            Matcher rangeMatch = rangePattern.matcher(token);
+            if (rangeMatch.matches()) {
+              int lower = Integer.parseInt(rangeMatch.group(1));
+              int upper = (rangeMatch.group(2) == null ? lower : Integer.parseInt(rangeMatch.group(2)));
+              reservedRanges.add(new EphemeralPorts.Range(lower, upper));
+            } else {
+              LOGGER.warn("Failed to match '{}' from {}", token, SOURCE);
+            }
+          }
+          if (reservedRanges.isEmpty()) {
+            LOGGER.debug("No reserved port ranges parsed from {}", SOURCE);
+          }
+        }
+
+      } catch (IOException e) {
+        LOGGER.warn("Unable to determine reserved ports", e);
+        return Collections.emptyList();
+      }
+
+      return Collections.unmodifiableList(reservedRanges);
+    }
+  }
+
+  /**
+   * Determine the reserved ports on a Windows platform.
+   */
+  private static class Windows {
+    List<EphemeralPorts.Range> getRanges() {
+      List<EphemeralPorts.Range> excludedRanges = new ArrayList<>();
+
+      try {
+        // and use netsh to determine dynamic port range
+        File netshExe = new File(Os.findWindowsSystemRoot(), "netsh.exe");
+
+        String[] cmd = { netshExe.getAbsolutePath(), "interface", "ipv4", "show", "excludedportrange", "protocol=tcp" };
+        Shell.Result result = Shell.execute(Shell.Encoding.CHARSET,
+            cmd);
+        if (result.exitCode() != 0) {
+          LOGGER.warn("Cannot determine excluded ports: command {} failed; rc={}:%n    {}",
+              Arrays.toString(cmd), result.exitCode(), String.join("\n    ", result));
+          return Collections.emptyList();
+        }
+
+        Pattern pattern = Pattern.compile("^\\s+(\\d+)\\s+(\\d+).*");
+        for (String line : result) {
+          Matcher matcher = pattern.matcher(line);
+          if (matcher.matches()) {
+            excludedRanges.add(
+                new EphemeralPorts.Range(Integer.parseInt(matcher.group(1)), Integer.parseInt(matcher.group(2))));
+          }
+        }
+
+      } catch (Exception e) {
+        LOGGER.warn("Unable to excluded port ranges", e);
+        return Collections.emptyList();
+      }
+
+      return Collections.unmodifiableList(excludedRanges);
+    }
+  }
+
+  public static void main(String[] args) {
+    ReservedPorts.getRange().forEach(System.out::println);
+  }
+}

--- a/port-chooser/src/test/java/org/terracotta/utilities/test/net/NetStatTest.java
+++ b/port-chooser/src/test/java/org/terracotta/utilities/test/net/NetStatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright 2020-2022 Terracotta, Inc., a Software AG company.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,12 +29,25 @@ public class NetStatTest {
 
   @Test
   public void testInfo() throws IOException {
-    // This test requires a properly functioning 'sudo --non-interactive -- lsof ...' on Linux
-    assumeTrue("'sudo --non-interactive -- lsof -iTCP not available", TestSupport.sudoLsofWorks());
+    // This test requires a properly functioning 'lsof ...' on Linux
+    assumeTrue("'lsof -iTCP not available", TestSupport.lsofWorks());
 
     try (PortManager.PortRef portRef = PortManager.getInstance().reservePort()) {
       try (ServerSocket openSocket = new ServerSocket(portRef.port())) {
         List<NetStat.BusyPort> busyPorts = NetStat.info();
+        assertTrue(busyPorts.stream().mapToInt(p -> p.localEndpoint().getPort()).anyMatch(p -> p == openSocket.getLocalPort()));
+      }
+    }
+  }
+
+  @Test
+  public void testInfoPort() throws IOException {
+    // This test requires a properly functioning 'lsof ...' on Linux
+    assumeTrue("'lsof -iTCP not available", TestSupport.lsofWorks());
+
+    try (PortManager.PortRef portRef = PortManager.getInstance().reservePort()) {
+      try (ServerSocket openSocket = new ServerSocket(portRef.port())) {
+        List<NetStat.BusyPort> busyPorts = NetStat.info(openSocket.getLocalPort());
         assertTrue(busyPorts.stream().mapToInt(p -> p.localEndpoint().getPort()).anyMatch(p -> p == openSocket.getLocalPort()));
       }
     }

--- a/port-chooser/src/test/java/org/terracotta/utilities/test/net/PortManagerTest.java
+++ b/port-chooser/src/test/java/org/terracotta/utilities/test/net/PortManagerTest.java
@@ -315,8 +315,8 @@ public class PortManagerTest {
   @SuppressWarnings("try")
   @Test
   public void testReleaseCheckEnabled() throws IOException {
-    // This test requires a properly functioning 'sudo --non-interactive -- lsof ...' on Linux
-    assumeTrue("'sudo --non-interactive -- lsof -iTCP not available", TestSupport.sudoLsofWorks());
+    // This test requires a properly functioning 'lsof ...' on Linux
+    assumeTrue("'lsof -iTCP not available", TestSupport.lsofWorks());
 
     // This test MUST be run when PortManager.DISABLE_PORT_RELEASE_CHECK_ENV_VARIABLE is false or not specified
     assertFalse(PortManager.DISABLE_PORT_RELEASE_CHECK_ENV_VARIABLE + " environment variable must be false or not specified",

--- a/port-chooser/src/test/java/org/terracotta/utilities/test/net/TestSupport.java
+++ b/port-chooser/src/test/java/org/terracotta/utilities/test/net/TestSupport.java
@@ -130,7 +130,7 @@ public final class TestSupport {
       Shell.Result result = Shell.execute(Shell.Encoding.CHARSET, lsofCommand);
       if (result.exitCode() == 0) {
         /*
-         * '-F n' causes the output to be "parsable" and include only groups od process IDs and network numbers.
+         * '-F n' causes the output to be "parsable" and include only groups of process IDs, FDs, and network numbers.
          * Ensure we actually got process groups with network numbers.
          */
         Map<String, List<String>> portsPerProcess = new LinkedHashMap<>();
@@ -147,12 +147,20 @@ public final class TestSupport {
               currentProcess = new ArrayList<>();
               portsPerProcess.put(line, currentProcess);
               break;
+            case 'f':
+              if (currentProcess == null) {
+                LOGGER.warn("Unexpected output from {}; missing process '{}'{}",
+                    Arrays.toString(lsofCommand), escape(line), collectEscapedLines(result));
+                return false;
+              }
+              break;
             case 'n':
               if (currentProcess == null) {
                 LOGGER.warn("Unexpected output from {}; missing process '{}'{}",
                     Arrays.toString(lsofCommand), escape(line), collectEscapedLines(result));
                 return false;
               }
+              currentProcess.add(line);
               break;
             default:
               LOGGER.warn("Unexpected output from {}: '{}'{}",

--- a/port-chooser/src/test/java/org/terracotta/utilities/test/net/TestSupport.java
+++ b/port-chooser/src/test/java/org/terracotta/utilities/test/net/TestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright 2020-2022 Terracotta, Inc., a Software AG company.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,8 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 /**
  * Static methods for to aid testing of {@link NetStat} and {@link PortManager}.
@@ -36,7 +38,8 @@ public final class TestSupport {
 
   private static final String[] SUDO_VERSION = new String[] { "sudo", "-V" };
   private static final String[] LSOF_VERSION = new String[] { "lsof", "-v" };
-  private static final String[] SUDO_LSOF_TCP = new String[] { "sudo", "--non-interactive", "--", "lsof", "-nP", "-iTCP", "-F", "n" };
+  private static final String[] LSOF_TCP = new String[] { "lsof", "-nP", "-iTCP", "-F", "n" };
+  private static final String[] SUDO_PREFIX = new String[] { "sudo", "--non-interactive", "--" };
 
   private TestSupport() {}
 
@@ -82,8 +85,49 @@ public final class TestSupport {
      * Both 'sudo' and 'lsof' are available on PATH.  Now check to see if 'sudo --non-interactive -- lsof -nP -iTCP -F n'
      * works and returns any useful results.
      */
+    String[] sudoLsofTcp = Arrays.copyOf(SUDO_PREFIX, SUDO_PREFIX.length + LSOF_TCP.length);
+    System.arraycopy(LSOF_TCP, 0, sudoLsofTcp, SUDO_PREFIX.length, LSOF_TCP.length);
+    return tryLsof(sudoLsofTcp);
+  }
+
+  /**
+   * Determines if {@code lsof -nP -iTCP ...} can be used to get TCP port information.
+   * This method ensures the following:
+   * <ol>
+   *   <li>{@code lsof} is available in {@code PATH}</li>
+   * </ol>
+   * ({@code lsof -nP -iTCP} will fail to return results if the platform implementation of {@code /proc} does
+   * not include sufficient for the network stack.)
+   *
+   * @return {@code true} if {@code lsof -nP -iTCP} returns expected results;
+   *    {@code false} otherwise
+   */
+  public static boolean lsofWorks() {
+
+    /*
+     * lsof is only used on Linux -- see org.terracotta.utilities.test.net.NetStat.Platform.LINUX
+     */
+    if (!Os.isLinux()) {
+      return true;
+    }
+
+    /*
+     * Ensure 'lsof' is accessible from PATH by getting its version.
+     */
+    if (!checkCommand(LSOF_VERSION)) {
+      return false;
+    }
+
+    /*
+     * 'lsof' is available on PATH.  Now check to see if 'lsof -nP -iTCP -F n'
+     * works and returns any useful results.
+     */
+    return tryLsof(LSOF_TCP);
+  }
+
+  private static boolean tryLsof(String[] lsofCommand) {
     try {
-      Shell.Result result = Shell.execute(Shell.Encoding.CHARSET, SUDO_LSOF_TCP);
+      Shell.Result result = Shell.execute(Shell.Encoding.CHARSET, lsofCommand);
       if (result.exitCode() == 0) {
         /*
          * '-F n' causes the output to be "parsable" and include only groups od process IDs and network numbers.
@@ -96,7 +140,8 @@ public final class TestSupport {
             case 'p':
               currentProcess = portsPerProcess.get(line);
               if (currentProcess != null) {
-                LOGGER.warn("Unexpected output from {}: multiple '{}'", Arrays.toString(SUDO_LSOF_TCP), escape(line));
+                LOGGER.warn("Unexpected output from {}: multiple '{}'{}",
+                    Arrays.toString(lsofCommand), escape(line), collectEscapedLines(result));
                 return false;
               }
               currentProcess = new ArrayList<>();
@@ -104,33 +149,43 @@ public final class TestSupport {
               break;
             case 'n':
               if (currentProcess == null) {
-                LOGGER.warn("Unexpected output from {}; missing process '{}'", Arrays.toString(SUDO_LSOF_TCP), escape(line));
+                LOGGER.warn("Unexpected output from {}; missing process '{}'{}",
+                    Arrays.toString(lsofCommand), escape(line), collectEscapedLines(result));
                 return false;
               }
               break;
             default:
-              LOGGER.warn("Unexpected output from {}: '{}'", Arrays.toString(SUDO_LSOF_TCP), escape(line));
+              LOGGER.warn("Unexpected output from {}: '{}'{}",
+                  Arrays.toString(lsofCommand), escape(line), collectEscapedLines(result));
               return false;
           }
         }
 
         if (portsPerProcess.isEmpty() || portsPerProcess.values().stream().allMatch(List::isEmpty)) {
-          String messages = "\n    " + String.join("\n    ", result);
-          LOGGER.debug("{} returned no ports:{}", Arrays.toString(SUDO_LSOF_TCP), messages);
+          LOGGER.debug("{} returned no ports:{}", Arrays.toString(lsofCommand), collectEscapedLines(result));
           return false;
         }
 
         return true;
 
       } else {
-        String messages = "\n    " + String.join("\n    ", result);
-        LOGGER.debug("Failed to run {}; rc={}{}", Arrays.toString(SUDO_LSOF_TCP), result.exitCode(), messages);
+        LOGGER.debug("Failed to run {}; rc={}{}", Arrays.toString(lsofCommand), result.exitCode(), collectEscapedLines(result));
         return false;
       }
     } catch (IOException e) {
-      LOGGER.debug("Failed to run {}", Arrays.toString(SUDO_LSOF_TCP), e);
+      LOGGER.debug("Failed to run {}", Arrays.toString(lsofCommand), e);
       return false;
     }
+  }
+
+  private static String collectEscapedLines(Iterable<String> lines) {
+    String messages = StreamSupport.stream(lines.spliterator(), false)
+        .map(TestSupport::escape)
+        .collect(Collectors.joining("\n    "));
+    if (!messages.isEmpty()) {
+      messages = "\n    " + messages;
+    }
+    return messages;
   }
 
   private static boolean checkCommand(String[] command) {

--- a/tools/src/main/java/org/terracotta/utilities/io/Files.java
+++ b/tools/src/main/java/org/terracotta/utilities/io/Files.java
@@ -672,7 +672,7 @@ public final class Files {
    * interference from system tasks.
    * <p>
    * The following options are supported:
-   * <table border=1 cellpadding=5 summary="">
+   * <table border=1>
    * <tr> <th>Option</th> <th>Description</th> </tr>
    * <tr>
    *   <td>{@link StandardCopyOption#REPLACE_EXISTING REPLACE_EXISTING}</td>

--- a/tools/src/test/java/org/terracotta/utilities/io/FilesRelocateTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/io/FilesRelocateTest.java
@@ -157,7 +157,7 @@ public class FilesRelocateTest extends FilesRelocateTestBase {
       assertTrue("actualTree is smaller than expectedTree:\n    actual=" + actualDetails + "\n    expected=" + expectedDetails, actualIterator.hasNext());
       PathDetails expectedDetail = expectedIterator.next();
       PathDetails actualDetail = actualIterator.next();
-      assertTrue("Target " + actualDetails + " does not mirror\n    source " + expectedDetail, actualDetail.mirrors(expectedDetail, true));
+      assertTrue("Target " + actualDetail + " does not mirror\n    source " + expectedDetail, actualDetail.mirrors(expectedDetail, true));
     }
     assertFalse("actualTree is larger than expectedTree:\n    actual=" + actualDetails + "\n    expected=" + expectedDetails, actualIterator.hasNext());
   }


### PR DESCRIPTION
This commit stream includes the commits from PR #60 and PR #61 and closes issue #59.

This commit stream includes the following, mostly related to PortManager and NetStat:

* Add DISABLE_PORT_RELEASE_CHECK environment variable
 This commit enables the use of the 'DISABLE_PORT_RELEASE_CHECK' environment variable to, when set to 'true', disable the port release check performed by PortManager.

* Treat TIME_WAIT as normal TCP connection status
  This commit removes TCP connections in a TIME_WAIT status from the results displayed by the port release check performed by PortManager.

  This commit also adds Javadoc for NetStat.BusyPort.TcpState describing the possible TCP connection state transitions. The diagrams in the documentation require Java 11+ to generate and, for a _complete_ build, now requires Java 11.  (Java 8 may continue to be used but the result will lack the diagrams.)

* Remove Javadoc HTML5 errors

* Preinstall fontconfig for PlantUML / separate javadoc
  Contrary to the descriptions, this pair of commits alters the CI jobs to:
  * split Javadoc generation (testing) out of the regular CI matrix
  * adds a CI job, running on Ubuntu with fontconfig installed, to test generate the Javadoc

  (This is altered in the next commit -- could have been squashed but wanted to keep @akomakom contribution noted.)

* Use Windows platform for Javadoc generation test

* Mark excluded/reserved ports as restricted
  Windows and Linux platforms have the ability to remove ports from use by bind(0).  This commit determines the configured reserved ports and marks them as restricted in PortManager.

* Limit query done by port release check to port being released
  Before this commit, the PortManager port release check queried details about all open ports and filtered the results to the port being released. This proved quite slow in some circumstances so NetStat is changed to add a method that, on Linux and Windows, queries only the port being checked.  (The port query method used for Mac OS X does not support querying a single port.)  PortManager is changed to use this single-port method when performing the release check.

* Correct FileSystemException "Operation not supported" on NFS mount
  This commit adds code to FileTestBase to avoid using a path's DosFileAttributeView if the FileStore for that path does not support the "dos" FileAttributeView.  The Linux file system, in general, does support the "dos" view but Files.getFileAttributeView does not consider a file system containing non-homogenous file stores.

* Replace Centos containers with AlmaLinux containers
  This commit updates the containers used from Centos to AlmaLinux.  This commit also installs lsof in the containers run as root.

* Correct for presence of FD in 'lsof ... -F n'
  This commit corrects TestSupport.lsofWorks to tolerate the presence of the FD number in 'lsof ... -F n' output.