### PR TITLE
Update Spotbugs to permit build under Java 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
         <plugin>
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
-          <version>4.0.0</version>
+          <version>4.7.3.0</version>
           <configuration>
             <xmlOutput>true</xmlOutput>
           </configuration>


### PR DESCRIPTION
This commit updates the Spotbugs dependency to permit building under a Java 17 JDK.