### PR TITLE
Correct Sonatype verification issues with generated POMs

### DIFF
--- a/buildSrc/src/main/kotlin/org.terracotta.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/org.terracotta.java-conventions.gradle.kts
@@ -75,6 +75,8 @@ publishing {
 
         pom {
             description.convention(project.provider { project.description })
+            name.convention(project.provider { project.extra["pomName"] as String })
+            url.convention("https://github.com/terracotta-oss/terracotta-utilities/")
 
             licenses {
                 license {

--- a/port-chooser/build.gradle.kts
+++ b/port-chooser/build.gradle.kts
@@ -5,7 +5,8 @@ plugins {
 
 val logbackRangeVersion: String by project
 
-description = "Terracotta Utilities Port Chooser"
+extra["pomName"] = "Terracotta Utilities Port Chooser"
+description = "Utility classes for TCP port management"
 
 dependencies {
     api(project(":terracotta-utilities-tools")) {

--- a/test-tools/build.gradle.kts
+++ b/test-tools/build.gradle.kts
@@ -7,7 +7,8 @@ val hamcrestVersion: String by project
 val junitVersion: String by project
 val slf4jRangeVersion: String by project
 
-description = "Terracotta Utilities Test Tools"
+extra["pomName"] = "Terracotta Utilities Test Tools"
+description = "Utility classes/methods for use in testing"
 
 /*
  * See README.md for a description of the use of the feature/capability and

--- a/tools/build.gradle.kts
+++ b/tools/build.gradle.kts
@@ -4,7 +4,8 @@ plugins {
 
 val logbackRangeVersion: String by project
 
-description = "Terracotta Utilities Tools"
+extra["pomName"] = "Terracotta Utilities Tools"
+description = "Utility classes/methods for common Java tasks"
 
 dependencies {
     testImplementation(project(":terracotta-utilities-test-tools"))


### PR DESCRIPTION
This commit sets the POM name and URL that were missing from the generated POM of each project and flagged during Sonatype repository verification.