### PR TITLE
MANIFEST.MF and LICENSE corrections

### DIFF
--- a/buildSrc/src/main/kotlin/org.terracotta.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/org.terracotta.java-conventions.gradle.kts
@@ -188,7 +188,7 @@ tasks {
                 "Build-Jdk-Spec" to jdkSpec,
                 "Built-By" to System.getProperty("user.name"),
                 "Build-Jdk" to System.getProperty("java.version"),
-                "Specification-Title" to project.description,
+                "Specification-Title" to project.extra["pomName"],
                 "Specification-Version" to specVersion(project.version.toString()),
                 "Implementation-Title" to project.name,
                 "Implementation-Vendor-Id" to project.group,

--- a/test-tools/build.gradle.kts
+++ b/test-tools/build.gradle.kts
@@ -124,12 +124,20 @@ spotbugs {
     excludeFilter.value(layout.projectDirectory.file("config/spotbugs/excludeFilter.xml"))
 }
 
-tasks.sourcesJar {
+val junitLicense = project.copySpec {
     into("META-INF/licenses/junit/junit") {
         from(layout.projectDirectory) {
             include("*-junit*")
         }
     }
+}
+
+tasks.jar {
+    with(junitLicense)
+}
+
+tasks.sourcesJar {
+    with(junitLicense)
     into("") {
         from(layout.projectDirectory.file("README.md"))
     }


### PR DESCRIPTION
This commit corrects the Specification-Title in MANIFEST.MF and adds the
 JUnit license files to the terracotta-utilities-test-tools executable
 jar (as well as the sources jar).