### PR TITLE
Gradle: add release plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     base
     id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
     id("org.nosphere.apache.rat")
+    id("net.researchgate.release") version "3.0.2"
 }
 
 val defaultVersion: String by project
@@ -11,7 +12,6 @@ val sonatypeUser: String by project
 val sonatypePwd: String by project
 
 group = "org.terracotta"
-version = defaultVersion
 
 repositories {
     mavenCentral()      // See https://github.com/eskatos/creadur-rat-gradle/issues/26
@@ -37,4 +37,12 @@ nexusPublishing {
         delayBetween = Duration.ofSeconds((findProperty("delayBetweenRetriesInSeconds") ?: "10").toString().toLong())
         maxRetries = (findProperty("numberOfRetries") ?: "100").toString().toInt()
     }
+}
+
+release {
+    git {
+        requireBranch.set("master")
+    }
+    versionProperties.set(listOf("defaultVersion"))
+    tagTemplate.set("v\${version}")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,10 @@
 
+# This is the version driving the build
 defaultVersion=0.0.18-SNAPSHOT
+# This is only for the release plugin which requires a "version" property
+# It will be kept in sync by the plugin to match defaultVersion when running
+#   gradle release (or: gradle release -Prelease.useAutomaticVersion=true)
+version=0.0.18-SNAPSHOT
 
 spotbugsAnnotationsVersion=4.0.2
 


### PR DESCRIPTION
`./gradlew release -Prelease.useAutomaticVersion=true` will tag (non-snapshot) and update branch to version +1.  It doesn't pushj.

version moved to the properties file to stop confusing the plugin.  
We can also remove `defaultVersion` altogether.  Doing so will break the current releaser (but it needs to change for this anyway)