### PR TITLE
Introduce AbstractRepeatingTest and FileCapturedPrintStream

### DIFF
--- a/test-tools/build.gradle.kts
+++ b/test-tools/build.gradle.kts
@@ -71,6 +71,8 @@ configurations {
 }
 
 dependencies {
+    implementation(project(":terracotta-utilities-tools"))
+
     "mainApi"("org.hamcrest:hamcrest:${hamcrestVersion}")
     "mainApi"("junit:junit:${junitVersion}") {
         exclude(mapOf("group" to "org.hamcrest"))

--- a/test-tools/src/main/java/org/terracotta/utilities/test/AbstractRepeatingRunListener.java
+++ b/test-tools/src/main/java/org/terracotta/utilities/test/AbstractRepeatingRunListener.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 Terracotta, Inc., a Software AG company.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.utilities.test;
+
+import org.junit.runner.notification.RunListener;
+
+/**
+ * Base {@code RunListener} implementation for {@link AbstractRepeatingTest} implementations.
+ *
+ * @see <a href="https://junit.org/junit4/javadoc/latest/org/junit/runner/notification/RunListener.html">org.junit.runner.notification.RunListener</a>
+ */
+public abstract class AbstractRepeatingRunListener extends RunListener {
+  private int iteration = 0;
+
+  /**
+   * Sets the current test iteration number.  This method called by {@link AbstractRepeatingTest}
+   * to inform this listener of the current repeat iteration.
+   * @param iteration the iteration number
+   */
+  final void setIteration(int iteration) {
+    this.iteration = iteration;
+  }
+
+  /**
+   * Gets the current test repeat iteration number.  The value returned is set by
+   * {@link AbstractRepeatingTest} when starting a repeated test cycle.
+   * @return the current test iteration number
+   */
+  public final int iteration() {
+    return iteration;
+  }
+}

--- a/test-tools/src/main/java/org/terracotta/utilities/test/AbstractRepeatingTest.java
+++ b/test-tools/src/main/java/org/terracotta/utilities/test/AbstractRepeatingTest.java
@@ -1,0 +1,363 @@
+/*
+ * Copyright 2023 Terracotta, Inc., a Software AG company.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.utilities.test;
+
+import org.junit.Rule;
+import org.junit.experimental.results.PrintableResult;
+import org.junit.rules.TestName;
+import org.junit.runner.Description;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Request;
+import org.junit.runner.Result;
+import org.junit.runner.notification.Failure;
+import org.terracotta.org.junit.rules.TemporaryFolder;
+import org.terracotta.utilities.io.CapturedPrintStream;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Path;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Foundation on which to build JUnit test class used to repeat another test.
+ * <p>
+ * To use, implement a concrete class, extending this class, in the same module as the test or
+ * test suite to be repeated.  For example, the following concrete class will repeat the
+ * <i>parameterized</i> test {@code ClassHoldingTestsToRepeat.testMethodName} for the
+ * {@code parameterId} parameter set 5000 times or until it fails.
+ * <pre><code>
+ * public class FooTest extends AbstractRepeatingTest {
+ *   &#x40;Test
+ *   public void testFoo() throws Exception {
+ *     int repeatCount = 5000;
+ *     Request testMethod = Request.method(ClassHoldingTestsToRepeat.class, "testMethodName[parameterId]");
+ *     repeatTestRequest(repeatCount, testMethod);
+ *   }
+ * }
+ * </code></pre>
+ *
+ * The {@code Request} can be composed of any collection of tests supported by the methods in the {@code Request} class.
+ *
+ * @see <a href="https://junit.org/junit4/javadoc/latest/org/junit/runner/Request.html"><code>org.junit.runner.Request</code></a>
+ * @see <a href="https://junit.org/junit4/javadoc/latest/org/junit/runner/notification/RunListener.html">org.junit.runner.notification.RunListener</a>
+ */
+public abstract class AbstractRepeatingTest {
+  @Rule
+  public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @Rule
+  public final TestName testName = new TestName();
+
+  /**
+   * Repeats the indicated test (or tests) the given number of times or until a test fails.
+   * <p>
+   * This method uses an internal {@link AbstractRepeatingRunListener} implementation to report all
+   * <a href="https://junit.org/junit4/javadoc/latest/org/junit/runner/notification/RunListener.html">RunListener</a>
+   * events to {@code System.out}.
+   * <p>
+   * <b>This method <i>substitutes</i> "capture" files for {@code System.out} and {@code System.err}.
+   * Tests relying on output to {@code System.out} or {@code System.err} may be incompatible with this method.</b>
+   * <p>
+   * If a test fails,
+   * <ol>
+   *   <li>The JUnit failure summary is emitted to {@code System.out}.</li>
+   *   <li>The captured {@code stdout} content for the failing test(s) is copied to {@code System.out};
+   *      this output is wrapped in marker lines <pre>{@code
+   *        >>> Begin failing stdout
+   *        ...
+   *        <<< End failing stdout
+   *      }</pre></li>
+   *   <li>The captured {@code stderr} content for the failing test(s) is copies to {@code System.err};
+   *       this output is wrapped in marker lines <pre>{@code
+   *         >>> Begin failing stderr
+   *         ...
+   *         <<< End failing stderr
+   *       }</pre></li>
+   *   <li>An {@code AssertionError} is thrown with the failure exception for each failing test present
+   *      as a suppressed exception.</li>
+   * </ol>
+   * <p>
+   * Each successful, skipped, or ignored test execution is recorded to {@code System.out}.
+   *
+   * @param repeatCount the maximum number of times to repeat the test(s)
+   * @param testMethod  the JUnit {@code Request} identifying the test(s) to run
+   * @throws IOException if an error is raised while accessing one of the output capture files
+   * @throws AssertionError if a test fails; the {@code AssertionError} instance will contain, as
+   *      suppressed exceptions, the failure(s) from the tests
+   * @see <a href="https://junit.org/junit4/javadoc/latest/org/junit/runner/notification/RunListener.html">org.junit.runner.notification.RunListener</a>
+   */
+  protected final void repeatTestRequest(int repeatCount, Request testMethod) throws IOException, AssertionError {
+    repeatTestRequest(repeatCount, testMethod, new LocalListener(System.out, EnumSet.allOf(ListenerEvents.class)));
+  }
+
+  /**
+   * Repeats the indicated test (or tests) the given number of times or until a test fails.
+   * <p>
+   * This method uses an internal {@link AbstractRepeatingRunListener} implementation to report
+   * <a href="https://junit.org/junit4/javadoc/latest/org/junit/runner/notification/RunListener.html">RunListener</a>
+   * events identified by {@code enabledEvents} to {@code System.out}.
+   * <p>
+   * <b>This method <i>substitutes</i> "capture" files for {@code System.out} and {@code System.err}.
+   * Tests relying on output to {@code System.out} or {@code System.err} may be incompatible with this method.</b>
+   * <p>
+   * If a test fails,
+   * <ol>
+   *   <li>The JUnit failure summary is emitted to {@code System.out}.</li>
+   *   <li>The captured {@code stdout} content for the failing test(s) is copied to {@code System.out};
+   *      this output is wrapped in marker lines <pre>{@code
+   *        >>> Begin failing stdout
+   *        ...
+   *        <<< End failing stdout
+   *      }</pre></li>
+   *   <li>The captured {@code stderr} content for the failing test(s) is copies to {@code System.err};
+   *       this output is wrapped in marker lines <pre>{@code
+   *         >>> Begin failing stderr
+   *         ...
+   *         <<< End failing stderr
+   *       }</pre></li>
+   *   <li>An {@code AssertionError} is thrown with the failure exception for each failing test present
+   *      as a suppressed exception.</li>
+   * </ol>
+   * <p>
+   * Each successful, skipped, or ignored test execution is recorded to {@code System.out}.
+   *
+   * @param repeatCount the maximum number of times to repeat the test(s)
+   * @param testMethod  the JUnit {@code Request} identifying the test(s) to run
+   * @param enabledEvents the set of {@link ListenerEvents} for which information is written to stdout;
+   *                      an empty set suppresses output for all events
+   * @throws IOException if an error is raised while accessing one of the output capture files
+   * @throws AssertionError if a test fails; the {@code AssertionError} instance will contain, as
+   *      suppressed exceptions, the failure(s) from the tests
+   * @see ListenerEvents
+   * @see <a href="https://junit.org/junit4/javadoc/latest/org/junit/runner/notification/RunListener.html">org.junit.runner.notification.RunListener</a>
+   */
+  protected final void repeatTestRequest(int repeatCount, Request testMethod, Set<ListenerEvents> enabledEvents)
+      throws IOException, AssertionError {
+    repeatTestRequest(repeatCount, testMethod, new LocalListener(System.out, Objects.requireNonNull(enabledEvents)));
+  }
+
+  /**
+   * Repeats the indicated test (or tests) the given number of times or until a test fails.
+   * <p>
+   * <b>This method <i>substitutes</i> "capture" files for {@code System.out} and {@code System.err}.
+   * Tests relying on output to {@code System.out} or {@code System.err} may be incompatible with this method.</b>
+   * <p>
+   * If a test fails,
+   * <ol>
+   *   <li>The JUnit failure summary is emitted to {@code System.out}.</li>
+   *   <li>The captured {@code stdout} content for the failing test(s) is copied to {@code System.out};
+   *      this output is wrapped in marker lines <pre>{@code
+   *        >>> Begin failing stdout
+   *        ...
+   *        <<< End failing stdout
+   *      }</pre></li>
+   *   <li>The captured {@code stderr} content for the failing test(s) is copies to {@code System.err};
+   *       this output is wrapped in marker lines <pre>{@code
+   *         >>> Begin failing stderr
+   *         ...
+   *         <<< End failing stderr
+   *       }</pre></li>
+   *   <li>An {@code AssertionError} is thrown with the failure exception for each failing test present
+   *      as a suppressed exception.</li>
+   * </ol>
+   * <p>
+   * Each successful, skipped, or ignored test execution is recorded to {@code System.out}.
+   *
+   * @param repeatCount the maximum number of times to repeat the test(s)
+   * @param testMethod  the JUnit {@code Request} identifying the test(s) to run
+   * @param listener the non-{@code null} {@code AbstractRepeatingRunListener} to receive JUnit test events
+   * @throws IOException if an error is raised while accessing one of the output capture files
+   * @throws AssertionError if a test fails; the {@code AssertionError} instance will contain, as
+   *      suppressed exceptions, the failure(s) from the tests
+   *
+   * @see <a href="https://junit.org/junit4/javadoc/latest/org/junit/runner/notification/RunListener.html">org.junit.runner.notification.RunListener</a>
+   */
+  protected final void repeatTestRequest(int repeatCount, Request testMethod, AbstractRepeatingRunListener listener)
+      throws IOException, AssertionError {
+    if (repeatCount <= 0) {
+      throw new IllegalArgumentException("repeatCount must be a positive integer");
+    }
+    Objects.requireNonNull(testMethod, "testMethod cannot be null" );
+    Objects.requireNonNull(listener, "listener cannot be null" );
+
+    JUnitCore core = new JUnitCore();
+    core.addListener(listener);
+
+    Path outPath = temporaryFolder.newFile(testName.getMethodName() + ".stdout").toPath();
+    Path errPath = temporaryFolder.newFile(testName.getMethodName() + ".stderr").toPath();
+
+    /*
+     * While capturing stdout and stderr output, run the test for the specified repeat count or
+     * until the test fails.  If the test fails, copy the captured stdout and stderr to the
+     * test's original stdout and stderr and
+     */
+    try (CapturedPrintStream captureStdout = CapturedPrintStream.getInstance(outPath);
+         CapturedPrintStream captureStderr = CapturedPrintStream.getInstance(errPath)) {
+
+      for (int i = 0; i < repeatCount; i++) {
+        int iteration = i + 1;
+        listener.setIteration(iteration);
+
+        PrintStream stdout = System.out;
+        PrintStream stderr = System.err;
+
+        System.setOut(captureStdout);
+        System.setErr(captureStderr);
+
+        long testStartTime = System.currentTimeMillis();
+        captureStdout.format("%1$tT.%1tL [%02d] Begin STDOUT for iteration=%2$d%n", testStartTime, iteration);
+        captureStderr.format("%1$tT.%1tL [%02d] Begin STDERR for iteration=%2$d%n", testStartTime, iteration);
+
+        Result result;
+        try {
+          result = core.run(testMethod);
+        } finally {
+          System.setErr(stderr);
+          System.setOut(stdout);
+
+          long testEndTime = System.currentTimeMillis();
+          captureStdout.format("%1$tT.%1tL [%02d] End STDOUT for iteration=%2$d%n", testEndTime, iteration);
+          captureStderr.format("%1$tT.%1tL [%02d] End STDERR for iteration=%2$d%n", testEndTime, iteration);
+          captureStdout.flush();
+          captureStderr.flush();
+        }
+
+        if (result.wasSuccessful()) {
+          // Output from a successful test is of no interest; reset the capture files
+          captureStdout.reset();
+          captureStderr.reset();
+
+        } else {
+          // Emit the details for a failed test and terminate the test cycling
+          List<Failure> failures = result.getFailures();
+          System.out.print(new PrintableResult(failures));
+
+          System.out.println(">>> Begin failing stdout");
+          captureStdout.getReader().lines().forEachOrdered(System.out::println);
+          System.out.println("<<< End failing stdout");
+
+          System.err.println(">>> Begin failing stderr");
+          captureStderr.getReader().lines().forEachOrdered(System.err::println);
+          System.err.println("<<< End failing stderr");
+
+          AssertionError totalFailure = new AssertionError("Failed running iteration " + iteration);
+          for (Failure failure : failures) {
+            totalFailure.addSuppressed(failure.getException());
+          }
+          throw totalFailure;
+        }
+      }
+    }
+  }
+
+  /*
+   * JUnit {@code RunListener} to emit test tracking messages.
+   */
+  private static class LocalListener extends AbstractRepeatingRunListener {
+    private final PrintStream out;
+    private final Set<ListenerEvents> activeEvents;
+
+    LocalListener(PrintStream out, Set<ListenerEvents> activeEvents) {
+      this.out = out;
+      this.activeEvents = activeEvents;
+    }
+
+    @Override
+    public void testRunStarted(Description description) {
+      if (activeEvents.contains(ListenerEvents.RUN_STARTED)) {
+        out.format("%n%1$tT.%1tL [%02d] Starting %s; iteration=%2$d%n",
+            System.currentTimeMillis(), iteration(), description);
+      }
+    }
+
+    @Override
+    public void testStarted(Description description) {
+      if (activeEvents.contains(ListenerEvents.TEST_STARTED)) {
+        out.format("%1$tT.%1tL [%02d] Starting %s; iteration=%2$d%n",
+            System.currentTimeMillis(), iteration(), description);
+      }
+    }
+
+    @Override
+    public void testFinished(Description description) {
+      if (activeEvents.contains(ListenerEvents.TEST_FINISHED)) {
+        out.format("%1$tT.%1tL [%02d] Completed %s; iteration=%2$d%n",
+            System.currentTimeMillis(), iteration(), description);
+      }
+    }
+
+    @Override
+    public void testFailure(Failure failure) {
+      if (activeEvents.contains(ListenerEvents.TEST_FAILED)) {
+        out.format("%n%1$tT.%1tL [%02d] Failed %s; iteration=%2$d%n    %s%n",
+            System.currentTimeMillis(), iteration(), failure.getDescription(), failure.getException());
+      }
+    }
+
+    @Override
+    public void testAssumptionFailure(Failure failure) {
+      if (activeEvents.contains(ListenerEvents.TEST_SKIPPED)) {
+        out.format("%1$tT.%1tL [%02d] Skipped %s; iteration=%2$d%n    %s%n",
+            System.currentTimeMillis(), iteration(), failure.getDescription(), failure.getException());
+      }
+    }
+
+    @Override
+    public void testIgnored(Description description) {
+      if (activeEvents.contains(ListenerEvents.TEST_IGNORED)) {
+        out.format("%1$tT.%1tL [%02d] Ignored %s; iteration=%2$d%n",
+            System.currentTimeMillis(), iteration(), description);
+      }
+    }
+
+    @Override
+    public void testRunFinished(Result result) {
+      if (activeEvents.contains(ListenerEvents.RUN_FINISHED)) {
+        out.format("%1$tT.%1tL [%02d] Ended  Runtime=%.3f s%n",
+            System.currentTimeMillis(), iteration(), result.getRunTime() / 1000f);
+        if (result.getFailureCount() != 0) {
+          out.println("Failed tests:");
+          result.getFailures().forEach(failure -> out.format("    %s%n", failure));
+        }
+        out.format("Tests run=%d, ignored=%d, failed=%d%n",
+            result.getRunCount(), result.getIgnoreCount(), result.getFailureCount());
+      }
+    }
+  }
+
+  /**
+   * Identifies {@code RunListener} events of the internal {@code RunListener} used by
+   * {@link AbstractRepeatingTest#repeatTestRequest(int, Request, Set)} to activate for output.
+   */
+  public enum ListenerEvents {
+    /** Activate calls to {@code RunListener.testRunStarted}. */
+    RUN_STARTED,
+    /** Activate calls to {@code RunListener.testRunFinished}. */
+    RUN_FINISHED,
+    /** Activate calls to {@code RunListener.testStarted}. */
+    TEST_STARTED,
+    /** Activate calls to {@code RunListener.testFinished}. */
+    TEST_FINISHED,
+    /** Activate calls to {@code RunListener.testFailure}. */
+    TEST_FAILED,
+    /** Activate calls to {@code RunListener.testIgnored}. */
+    TEST_IGNORED,
+    /** Activate calls to {@code RunListener.testAssumptionFailure}. */
+    TEST_SKIPPED
+  }
+}

--- a/test-tools/src/test/java/org/terracotta/utilities/test/SampleRepeatingTest.java
+++ b/test-tools/src/test/java/org/terracotta/utilities/test/SampleRepeatingTest.java
@@ -1,0 +1,415 @@
+/*
+ * Copyright 2023 Terracotta, Inc., a Software AG company.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.utilities.test;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.Request;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.terracotta.utilities.io.CapturedPrintStream;
+
+import java.io.PrintStream;
+import java.text.MessageFormat;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
+import static org.terracotta.utilities.test.matchers.ThrowsMatcher.threw;
+
+/**
+ * Basic tests for {@link AbstractRepeatingTest}.
+ * <p>
+ * This test class includes a nested test class holding tests that should not be run
+ * as a top-level test; the nested test class is run by the tests in this top-level class.
+ */
+public class SampleRepeatingTest extends AbstractRepeatingTest {
+
+  private static final Map<String, TestParameters> TEST_PARAMETERS_MAP = TestParameters.toMap();
+
+  @Test
+  public void testNegativeIterationCount() {
+    Request testMethod = Request.method(SampleParameterizedTests.class, "foo");
+    assertThat(() -> repeatTestRequest(-1, testMethod), threw(instanceOf(IllegalArgumentException.class)));
+    assertThat(() -> repeatTestRequest(-1, testMethod, EnumSet.noneOf(ListenerEvents.class)), threw(instanceOf(IllegalArgumentException.class)));
+    assertThat(() -> repeatTestRequest(-1, testMethod, new AbstractRepeatingRunListener() {}), threw(instanceOf(IllegalArgumentException.class)));
+  }
+
+  @Test
+  public void testNullRequest() {
+    assertThat(() -> repeatTestRequest(1, null), threw(instanceOf(NullPointerException.class)));
+    assertThat(() -> repeatTestRequest(1, null, EnumSet.noneOf(ListenerEvents.class)), threw(instanceOf(NullPointerException.class)));
+    assertThat(() -> repeatTestRequest(1, null, new AbstractRepeatingRunListener() {}), threw(instanceOf(NullPointerException.class)));
+  }
+
+  @Test
+  public void testNullListenerEvents() {
+    Request testMethod = Request.method(SampleParameterizedTests.class, "foo");
+    assertThat(() -> repeatTestRequest(1, testMethod, (Set<ListenerEvents>)null), threw(instanceOf(NullPointerException.class)));
+  }
+
+  @Test
+  public void testNullListener() {
+    Request testMethod = Request.method(SampleParameterizedTests.class, "foo");
+    assertThat(() -> repeatTestRequest(1, testMethod, (AbstractRepeatingRunListener)null), threw(instanceOf(NullPointerException.class)));
+  }
+
+  @Test
+  public void testRepeatedSuccessfulTest() throws Exception {
+    TestParameters testParameters = TEST_PARAMETERS_MAP.get(testName.getMethodName());
+    String testMethodName = testParameters.testName("testSomething");
+    int repeatCount = testParameters.iterationsToFailure() - 1;
+    Request testMethod = Request.method(SampleParameterizedTests.class, testMethodName);
+
+    PrintStream originalOut = System.out;
+    PrintStream originalErr = System.err;
+    try (CapturedPrintStream testOut = CapturedPrintStream.getInstance();
+         CapturedPrintStream testErr = CapturedPrintStream.getInstance()) {
+
+      swapPrintStreams(testOut, testErr);
+      try {
+        repeatTestRequest(repeatCount, testMethod);
+      } finally {
+        swapPrintStreams(originalOut, originalErr);
+      }
+
+      List<String> stdout = getAll(testOut);
+      stdout.forEach(System.out::println);
+      assertThat(stdout, hasItem(
+          both(containsString("Starting " + SampleParameterizedTests.class.getName())).and(containsString("iteration=" + repeatCount))));
+      assertThat(stdout, hasItem(
+          both(containsString("Starting " + testMethodName)).and(containsString("iteration=" + repeatCount))));
+      assertThat(stdout, hasItem(
+          both(containsString("Completed " + testMethodName)).and(containsString("iteration=" + repeatCount))));
+      assertThat(stdout, hasItem(containsString("Ended  Runtime")));
+
+      // Excludes the test output to stdout ...
+      assertThat(stdout, not(
+          hasItem(allOf(containsString(testMethodName), containsString(" Iteration=" + repeatCount),
+              containsString("success")))));
+
+      List<String> stderr = getAll(testErr);
+      assertThat(stderr, is((empty())));
+    }
+  }
+
+  @Test
+  public void testRepeatedFailedTest() {
+    TestParameters testParameters = TEST_PARAMETERS_MAP.get(testName.getMethodName());
+    String testMethodName = testParameters.testName("testSomething");
+    int iterationsToFailure = testParameters.iterationsToFailure();
+    int repeatCount = iterationsToFailure + 1;
+    Request testMethod = Request.method(SampleParameterizedTests.class, testMethodName);
+
+    PrintStream originalOut = System.out;
+    PrintStream originalErr = System.err;
+    try (CapturedPrintStream testOut = CapturedPrintStream.getInstance();
+         CapturedPrintStream testErr = CapturedPrintStream.getInstance()) {
+
+      swapPrintStreams(testOut, testErr);
+      try {
+        assertThat(() -> repeatTestRequest(repeatCount, testMethod), threw(instanceOf(AssertionError.class)));
+      } finally {
+        swapPrintStreams(originalOut, originalErr);
+      }
+
+      List<String> stdout = getAll(testOut);
+      assertThat(stdout, hasItem(
+          both(containsString("Failed " + testMethodName)).and(containsString("iteration=" + iterationsToFailure))));
+      assertThat(stdout, hasItem(startsWith("Failed tests")));
+      assertThat(stdout, hasItem(containsString("There was 1 failure:")));
+      assertThat(stdout, hasItem(containsString("1) " + testMethodName)));
+      assertThat(stdout, hasItem(containsString(testParameters.fault().getName() + ": " + testMethodName + " iteration=" + iterationsToFailure)));
+      assertThat(stdout, hasItem(containsString("Begin STDOUT for iteration=" + iterationsToFailure)));
+      assertThat(stdout, hasItem(containsString("End STDOUT for iteration=" + iterationsToFailure)));
+      assertThat(stdout, not(hasItem(containsString("Begin STDOUT for iteration=" + (iterationsToFailure - 1)))));
+      assertThat(stdout, not(hasItem(containsString("End STDOUT for iteration=" + (iterationsToFailure - 1)))));
+
+      List<String> stderr = getAll(testErr);
+      assertThat(stderr, hasItem(containsString("Begin STDERR for iteration=" + iterationsToFailure)));
+      assertThat(stderr, hasItem(
+          allOf(containsString(testMethodName), containsString(" Iteration=" + iterationsToFailure),
+              containsString("failing with " + testParameters.fault().getName() + ": " + testMethodName + " iteration=" + iterationsToFailure))));
+      assertThat(stderr, hasItem(containsString("End STDERR for iteration=" + iterationsToFailure)));
+    }
+  }
+
+  @Test
+  public void testSuppressedStdoutTest() throws Exception {
+    TestParameters testParameters = TEST_PARAMETERS_MAP.get(testName.getMethodName());
+    String testMethodName = testParameters.testName("testSomething");
+    int repeatCount = testParameters.iterationsToFailure() - 1;
+    Request testMethod = Request.method(SampleParameterizedTests.class, testMethodName);
+
+    PrintStream originalOut = System.out;
+    PrintStream originalErr = System.err;
+    try (CapturedPrintStream testOut = CapturedPrintStream.getInstance();
+         CapturedPrintStream testErr = CapturedPrintStream.getInstance()) {
+
+      swapPrintStreams(testOut, testErr);
+      try {
+        repeatTestRequest(repeatCount, testMethod, new AbstractRepeatingRunListener() {
+          // Test progress output suppressed
+        });
+      } finally {
+        swapPrintStreams(originalOut, originalErr);
+      }
+
+      List<String> stdout = getAll(testOut);
+      assertThat(stdout, is(empty()));
+
+      List<String> stderr = getAll(testErr);
+      assertThat(stderr, is(empty()));
+    }
+  }
+
+  @Test
+  public void testPresentStderrTest() {
+    TestParameters testParameters = TEST_PARAMETERS_MAP.get(testName.getMethodName());
+    String testMethodName = testParameters.testName("testSomething");
+    int iterationsToFailure = testParameters.iterationsToFailure();
+    int repeatCount = iterationsToFailure + 1;
+    Request testMethod = Request.method(SampleParameterizedTests.class, testMethodName);
+
+    PrintStream originalOut = System.out;
+    PrintStream originalErr = System.err;
+    try (CapturedPrintStream testOut = CapturedPrintStream.getInstance();
+         CapturedPrintStream testErr = CapturedPrintStream.getInstance()) {
+
+      swapPrintStreams(testOut, testErr);
+      try {
+        assertThat(() -> repeatTestRequest(repeatCount, testMethod, new AbstractRepeatingRunListener() {
+          // Test progress output suppressed
+        }), threw(instanceOf(AssertionError.class)));
+      } finally {
+        swapPrintStreams(originalOut, originalErr);
+      }
+
+      List<String> stdout = getAll(testOut);
+      assertThat(stdout, hasItem(containsString("There was 1 failure:")));
+      assertThat(stdout, hasItem(containsString("1) " + testMethodName)));
+      assertThat(stdout, hasItem(containsString(testParameters.fault().getName() + ": " + testMethodName + " iteration=" + iterationsToFailure)));
+      assertThat(stdout, hasItem(containsString("Begin STDOUT for iteration=" + iterationsToFailure)));
+      assertThat(stdout, hasItem(containsString("End STDOUT for iteration=" + iterationsToFailure)));
+      assertThat(stdout, not(hasItem(containsString("Begin STDOUT for iteration=" + (iterationsToFailure - 1)))));
+      assertThat(stdout, not(hasItem(containsString("End STDOUT for iteration=" + (iterationsToFailure - 1)))));
+
+      List<String> stderr = getAll(testErr);
+      assertThat(stderr, hasItem(containsString("Begin STDERR for iteration=" + iterationsToFailure)));
+      assertThat(stderr, hasItem(
+          allOf(containsString(testMethodName), containsString(" Iteration=" + iterationsToFailure),
+              containsString("failing with " + testParameters.fault().getName() + ": " + testMethodName + " iteration=" + iterationsToFailure))));
+      assertThat(stderr, hasItem(containsString("End STDERR for iteration=" + iterationsToFailure)));
+    }
+  }
+
+  @Test
+  public void testRepeatedSuccessfulTestSuppressedListener() throws Exception {
+    TestParameters testParameters = TEST_PARAMETERS_MAP.get(testName.getMethodName());
+    String testMethodName = testParameters.testName("testSomething");
+    int repeatCount = testParameters.iterationsToFailure() - 1;
+    Request testMethod = Request.method(SampleParameterizedTests.class, testMethodName);
+
+    PrintStream originalOut = System.out;
+    PrintStream originalErr = System.err;
+    try (CapturedPrintStream testOut = CapturedPrintStream.getInstance();
+         CapturedPrintStream testErr = CapturedPrintStream.getInstance()) {
+
+      swapPrintStreams(testOut, testErr);
+      try {
+        repeatTestRequest(repeatCount, testMethod,
+            EnumSet.complementOf(EnumSet.of(ListenerEvents.TEST_FINISHED, ListenerEvents.TEST_STARTED)));
+      } finally {
+        swapPrintStreams(originalOut, originalErr);
+      }
+
+      List<String> stdout = getAll(testOut);
+      assertThat(stdout, hasItem(
+          both(containsString("Starting " + SampleParameterizedTests.class.getName())).and(containsString("iteration=" + repeatCount))));
+      assertThat(stdout, not(hasItem(   // testStarted
+          both(containsString("Starting " + testMethodName)).and(containsString("iteration=" + repeatCount)))));
+      assertThat(stdout, not(hasItem(   // testFinished
+          both(containsString("Completed " + testMethodName)).and(containsString("iteration=" + repeatCount)))));
+      assertThat(stdout, hasItem(containsString("Ended  Runtime")));
+
+      // Excludes the test output to stdout ...
+      assertThat(stdout, not(
+          hasItem(allOf(containsString(testMethodName), containsString(" Iteration=" + repeatCount),
+              containsString("success")))));
+
+      List<String> stderr = getAll(testErr);
+      assertThat(stderr, is((empty())));
+    }
+  }
+
+  private static void swapPrintStreams(PrintStream stdout, PrintStream stderr) {
+    stdout.flush();
+    stderr.flush();
+    System.setOut(stdout);
+    System.setErr(stderr);
+  }
+
+  private static List<String> getAll(CapturedPrintStream printStream) {
+    try (Stream<String> stream = printStream.getReader().lines()) {
+      return stream.collect(toList());
+    }
+  }
+
+  /**
+   * Parameterized tests executed from {@link SampleRepeatingTest}.
+   * Why parameterized?  This serves as an example of how to refer to
+   * parameterized tests when constructing the {@code Request} passed
+   * to {@link AbstractRepeatingTest#repeatTestRequest}.
+   */
+  @SuppressWarnings("JUnitMalformedDeclaration")
+  @RunWith(Parameterized.class)
+  public static class SampleParameterizedTests {
+
+    @Parameterized.Parameters(name = "{0}:{1}")
+    public static List<Object[]> data() {
+      return Arrays.asList(new Object[][] {
+              { "testRepeatedSuccessfulTest", 10, (Function<String, Throwable>)AssertionError::new },
+              { "testRepeatedFailedTest", 5, (Function<String, Throwable>)AssertionError::new },
+              { "testSuppressedStdoutTest", 15, (Function<String, Throwable>)AssertionError::new },
+              { "testPresentStderrTest", 5, (Function<String, Throwable>)AssertionError::new },
+              { "testRepeatedSuccessfulTestSuppressedListener", 5, (Function<String, Throwable>)AssertionError::new },
+          }
+      );
+    }
+
+    @Parameterized.Parameter
+    public String caseName;
+
+    @Parameterized.Parameter(1)
+    public int iterationsToFailure;
+
+    @Parameterized.Parameter(2)
+    public Function<String, Throwable> failure;
+
+    @Rule
+    public final TestName testName = new TestName();
+
+    private int iterationCount;
+
+    private static final Map<String, Integer> TEST_ITERATION_COUNT = new ConcurrentHashMap<>();
+
+    @Before
+    public void countIterations() {
+      this.iterationCount = TEST_ITERATION_COUNT.compute(testName.getMethodName(), (k, v) -> {
+        if (v == null) {
+          return 1;
+        } else {
+          return v + 1;
+        }
+      });
+    }
+
+    @Test
+    public void testSomething() throws Throwable {
+      if (iterationCount >= iterationsToFailure) {
+        Throwable throwable = failure.apply(String.format("%s iteration=%d", testName.getMethodName(), iterationCount));
+        System.err.printf("[%s] Iteration=%d; failing with %s%n", testName.getMethodName(), iterationCount, throwable);
+        throw throwable;
+      }
+      System.out.printf("[%s] Iteration=%d; success", testName.getMethodName(), iterationCount);
+    }
+  }
+
+  private static class TestParameters {
+    private static final String PARAMETERIZED_TEST_ID;
+    static {
+      String testIdPattern;
+      try {
+        testIdPattern = SampleParameterizedTests.class.getDeclaredMethod("data")
+            .getDeclaredAnnotation(Parameterized.Parameters.class).name();
+      } catch (NoSuchMethodException e) {
+        testIdPattern = "{index}";
+      }
+      PARAMETERIZED_TEST_ID = testIdPattern;
+    }
+
+    private final int index;
+    private final String caseName;
+    private final int iterationsToFailure;
+    private final Class<? extends Throwable> fault;
+    private final String testId;
+
+    public static Map<String, TestParameters> toMap() {
+      List<Object[]> data = SampleParameterizedTests.data();
+      return IntStream.range(0, data.size())
+          .mapToObj(i -> TestParameters.instance(i, data.get(i)))
+          .collect(Collectors.toMap(TestParameters::caseName, Function.identity()));
+    }
+
+    public static TestParameters instance(int index, Object[] parameters) {
+      String caseName = (String)parameters[0];
+      int iterationsToFailure = (int)parameters[1];
+      @SuppressWarnings("unchecked") Class<? extends Throwable> fault =
+          ((Function<String, Throwable>)parameters[2]).apply("").getClass();  // unchecked
+      return new TestParameters(index, caseName, iterationsToFailure, fault);
+    }
+
+    private TestParameters(int index, String caseName, int iterationsToFailure, Class<? extends Throwable> fault) {
+      this.index = index;
+      this.caseName = caseName;
+      this.iterationsToFailure = iterationsToFailure;
+      this.fault = fault;
+      this.testId = formKey();
+    }
+
+    public String caseName() {
+      return caseName;
+    }
+
+    public int iterationsToFailure() {
+      return iterationsToFailure;
+    }
+
+    public Class<? extends Throwable> fault() {
+      return fault;
+    }
+
+    public String testName(String testMethod) {
+      return String.format("%s[%s]", testMethod, testId);
+    }
+
+    private String formKey() {
+      String format = PARAMETERIZED_TEST_ID.replaceAll(Pattern.quote("{index}"), Integer.toString(index));
+      return MessageFormat.format(format, caseName, iterationsToFailure, fault.getName());
+    }
+  }
+}

--- a/tools/src/main/java/org/terracotta/utilities/io/CapturedPrintStream.java
+++ b/tools/src/main/java/org/terracotta/utilities/io/CapturedPrintStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright 2020-2023 Terracotta, Inc., a Software AG company.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,35 +19,100 @@ import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.FileDescriptor;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.io.PrintStream;
+import java.io.UncheckedIOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.StandardOpenOption.APPEND;
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
 
 /**
- * Extends {@link PrintStream} to capture the output to an in-memory buffer.
+ * Extends {@link PrintStream} to capture the output to an in-memory or file-backed buffer.
  * The captured stream is available by calling {@link #getReader()}.
  * {@link StandardCharsets#UTF_8 UTF-8} is used for encoding and decoding the stream
  * content.
  *
  * @see #getInstance()
+ * @see #getInstance(Path)
+ * @see #getInstance(Path, boolean)
  */
-public final class CapturedPrintStream extends PrintStream {
+public abstract class CapturedPrintStream extends PrintStream {
 
-  private CapturedPrintStream() throws UnsupportedEncodingException {
-    super(new LocalBufferedOutputStream(4096), false, StandardCharsets.UTF_8.name());
+  volatile PrintStream delegate;
+
+  private CapturedPrintStream(PrintStream delegate) throws UnsupportedEncodingException {
+    super(new NullOutputStream(), false, UTF_8.name());
+    this.delegate = delegate;
   }
 
   /**
-   * Instantiates a new {@code CapturedPrintStream}.
+   * Instantiates a new {@code CapturedPrintStream} using file as a buffer and a caller-specified auto-flush setting.
+   * @param filePath {@code Path} to file used to capture stream output
+   * @param autoFlush {@code true} enables auto-flushing of the capture {@code PrintStream};
+   *          {@code false} disables auto-flushing of the capture {@code PrintStream}
+   * @return a new {@code CapturedPrintStream}
+   * @throws IOException if an error is raised opening an output stream over {@code filePath}
+   *
+   * @see PrintStream#PrintStream(OutputStream, boolean, String)
+   */
+  public static CapturedPrintStream getInstance(Path filePath, boolean autoFlush) throws IOException {
+    FileOutputStream fos = FileCapturedPrintStream.open(Objects.requireNonNull(filePath, "filePath"), CREATE, APPEND);
+    try {
+      return new FileCapturedPrintStream(filePath, fos, autoFlush);
+    } catch (UnsupportedEncodingException e) {
+      throw new AssertionError("Unexpected exception creating CapturedPrintStream", e);
+    }
+  }
+
+  /**
+   * Instantiates a new {@code CapturedPrintStream} using file as a buffer and auto-flush enabled.
+   * <p>
+   * This method is equivalent to <pre>{@code CapturedPrintStream.getInstance(filePath, true)}</pre>
+   * @param filePath {@code Path} to file used to capture stream output
+   * @return a new {@code CapturedPrintStream}
+   * @throws IOException if an error is raised opening an output stream over {@code filePath}
+   */
+  public static CapturedPrintStream getInstance(Path filePath) throws IOException {
+    return CapturedPrintStream.getInstance(filePath, true);
+  }
+
+  /**
+   * Instantiates a new {@code CapturedPrintStream} using an in-memory buffer.
    * @return a new {@code CapturedPrintStream}
    */
   public static CapturedPrintStream getInstance() {
     try {
-      return new CapturedPrintStream();
+      return new MemoryCapturedPrintStream(new LocalBufferedOutputStream(4096));
     } catch (UnsupportedEncodingException e) {
       throw new AssertionError("Unexpected exception creating CapturedPrintStream", e);
     }
+  }
+
+  /**
+   * Swaps in a new {@code PrintStream} delegate.
+   * @param newDelegate the {@code PrintStream} to use
+   */
+  final void swapDelegate(PrintStream newDelegate) {
+    delegate.flush();
+    delegate.close();
+    delegate = newDelegate;
   }
 
   /**
@@ -56,17 +121,12 @@ public final class CapturedPrintStream extends PrintStream {
    * @return a new {@code BufferedReader} over the bytes written to this stream
    * @see #reset()
    */
-  public BufferedReader getReader() {
-    return new BufferedReader(new InputStreamReader(new ByteArrayInputStream(toByteArray()), StandardCharsets.UTF_8), 4096);
-  }
+  public abstract BufferedReader getReader();
 
   /**
    * Discards the captured output.
    */
-  public void reset() {
-    flush();
-    ((LocalBufferedOutputStream)out).reset();
-  }
+  public abstract void reset();
 
   /**
    * Gets a copy of the content of this stream as a byte array.  The content of this
@@ -74,9 +134,310 @@ public final class CapturedPrintStream extends PrintStream {
    * @return a byte array containing a copy of the captured data
    * @see #reset()
    */
-  public byte[] toByteArray() {
-    flush();
-    return ((LocalBufferedOutputStream)out).toByteArray();
+  public abstract byte[] toByteArray();
+
+  @Override
+  public synchronized void flush() {
+    delegate.flush();
+  }
+
+  @Override
+  public synchronized void close() {
+    delegate.close();
+  }
+
+  @Override
+  public synchronized boolean checkError() {
+    return delegate.checkError();
+  }
+
+  @Override
+  public synchronized void write(int b) {
+    delegate.write(b);
+  }
+
+  @Override
+  public synchronized void write(byte[] buf, int off, int len) {
+    delegate.write(buf, off, len);
+  }
+
+  @Override
+  public synchronized void print(boolean b) {
+    delegate.print(b);
+  }
+
+  @Override
+  public synchronized void print(char c) {
+    delegate.print(c);
+  }
+
+  @Override
+  public synchronized void print(int i) {
+    delegate.print(i);
+  }
+
+  @Override
+  public synchronized void print(long l) {
+    delegate.print(l);
+  }
+
+  @Override
+  public synchronized void print(float f) {
+    delegate.print(f);
+  }
+
+  @Override
+  public synchronized void print(double d) {
+    delegate.print(d);
+  }
+
+  @Override
+  public synchronized void print(char[] s) {
+    delegate.print(s);
+  }
+
+  @Override
+  public synchronized void print(String s) {
+    delegate.print(s);
+  }
+
+  @Override
+  public synchronized void print(Object obj) {
+    delegate.print(obj);
+  }
+
+  @Override
+  public synchronized void println() {
+    delegate.println();
+  }
+
+  @Override
+  public synchronized void println(boolean x) {
+    delegate.println(x);
+  }
+
+  @Override
+  public synchronized void println(char x) {
+    delegate.println(x);
+  }
+
+  @Override
+  public synchronized void println(int x) {
+    delegate.println(x);
+  }
+
+  @Override
+  public synchronized void println(long x) {
+    delegate.println(x);
+  }
+
+  @Override
+  public synchronized void println(float x) {
+    delegate.println(x);
+  }
+
+  @Override
+  public synchronized void println(double x) {
+    delegate.println(x);
+  }
+
+  @Override
+  public synchronized void println(char[] x) {
+    delegate.println(x);
+  }
+
+  @Override
+  public synchronized void println(String x) {
+    delegate.println(x);
+  }
+
+  @Override
+  public synchronized void println(Object x) {
+    delegate.println(x);
+  }
+
+  @Override
+  public synchronized PrintStream printf(String format, Object... args) {
+    delegate.printf(format, args);
+    return this;
+  }
+
+  @Override
+  public synchronized PrintStream printf(Locale l, String format, Object... args) {
+    delegate.printf(l, format, args);
+    return this;
+  }
+
+  @Override
+  public synchronized PrintStream format(String format, Object... args) {
+    delegate.format(format, args);
+    return this;
+  }
+
+  @Override
+  public synchronized PrintStream format(Locale l, String format, Object... args) {
+    delegate.format(l, format, args);
+    return this;
+  }
+
+  @Override
+  public synchronized PrintStream append(CharSequence csq) {
+    delegate.append(csq);
+    return this;
+  }
+
+  @Override
+  public synchronized PrintStream append(CharSequence csq, int start, int end) {
+    delegate.append(csq, start, end);
+    return this;
+  }
+
+  @Override
+  public synchronized PrintStream append(char c) {
+    delegate.append(c);
+    return this;
+  }
+
+  @Override
+  public synchronized void write(byte[] b) throws IOException {
+    delegate.write(b);
+  }
+
+  /**
+   * A {@link PrintStream} to capture to a file-backed buffer.
+   * The captured stream is available by calling {@link #getReader()}.
+   * {@link StandardCharsets#UTF_8 UTF-8} is used for encoding and decoding the stream content.
+   * @see CapturedPrintStream#getInstance(Path)
+   */
+  public static final class FileCapturedPrintStream extends CapturedPrintStream {
+    private final Path filePath;
+    private final boolean autoFlush;
+
+    private volatile FileDescriptor fd;
+
+    private FileCapturedPrintStream(Path filePath, FileOutputStream fileOutputStream, boolean autoFlush) throws IOException {
+      super(new PrintStream(new BufferedOutputStream(fileOutputStream, 4096), autoFlush, UTF_8.name()));
+      this.filePath = filePath;
+      this.autoFlush = autoFlush;
+      this.fd = fileOutputStream.getFD();
+    }
+
+    private static FileOutputStream open(Path filePath, OpenOption... options) throws IOException {
+      Set<OpenOption> specifiedOptions = new HashSet<>(Arrays.asList(options));
+
+      if (specifiedOptions.contains(CREATE)) {
+        // Create the file if necessary
+        try {
+          Files.createFile(filePath);
+        } catch (FileAlreadyExistsException e) {
+          // file exists -- will be re-used
+        }
+      }
+
+      boolean append = !specifiedOptions.contains(TRUNCATE_EXISTING);
+      return new FileOutputStream(filePath.toFile(), append);
+    }
+
+    /**
+     * Ensures all buffered content is flushed to disk.
+     * @throws IOException if an error is raised from the {@link FileDescriptor#sync()} call
+     */
+    public void sync() throws IOException {
+      flush();
+      fd.sync();
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This method calls {@link #flush()} and {@link FileDescriptor#sync()} to ensure all captured
+     * output is available to the reader.
+     *
+     * @throws UncheckedIOException for a {@link FileCapturedPrintStream} if an {@link IOException} is
+     *        thrown when opening the file for reading
+     */
+    @Override
+    public synchronized BufferedReader getReader() {
+      try {
+        flush();
+        fd.sync();
+        return Files.newBufferedReader(filePath);
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This method <i>closes</i> the previous {@code PrintStream} delegate iff the new delegate is successfully created.
+     *
+     * @throws UncheckedIOException if an error is raised while opening the new delegate
+     */
+    @Override
+    public synchronized void reset() {
+      try {
+        FileOutputStream fos = open(filePath, CREATE, TRUNCATE_EXISTING);
+        swapDelegate(new PrintStream(new BufferedOutputStream(fos, 4096), autoFlush, UTF_8.name()));
+        this.fd = fos.getFD();
+      } catch (UnsupportedEncodingException e) {
+        throw new AssertionError("Unexpected exception creating file buffer for CapturedPrintStream", e);
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This method calls {@link #flush()} and {@link FileDescriptor#sync()} to ensure all captured
+     * output is available to the reader.
+     *
+     * @throws UncheckedIOException if an error is raised while reading the backing file
+     */
+    @Override
+    public synchronized byte[] toByteArray() {
+      try {
+        flush();
+        fd.sync();
+        return Files.readAllBytes(filePath);
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    }
+  }
+
+  /**
+   * A {@link PrintStream} to capture to a memory-based buffer.
+   * The captured stream is available by calling {@link #getReader()}.
+   * {@link StandardCharsets#UTF_8 UTF-8} is used for encoding and decoding the stream content.
+   * @see CapturedPrintStream#getInstance()
+   */
+  public static final class MemoryCapturedPrintStream extends CapturedPrintStream {
+
+    private final LocalBufferedOutputStream out;
+
+    private MemoryCapturedPrintStream(LocalBufferedOutputStream out) throws UnsupportedEncodingException {
+      super(new PrintStream(out, false, UTF_8.name()));
+      this.out = out;
+    }
+
+    @Override
+    public synchronized BufferedReader getReader() {
+      return new BufferedReader(new InputStreamReader(new ByteArrayInputStream(toByteArray()), UTF_8), 4096);
+    }
+
+    @Override
+    public synchronized void reset() {
+      flush();
+      out.reset();
+    }
+
+    @Override
+    public synchronized byte[] toByteArray() {
+      flush();
+      return out.toByteArray();
+    }
   }
 
   private static final class LocalBufferedOutputStream extends BufferedOutputStream {

--- a/tools/src/test/java/org/terracotta/utilities/io/CapturedPrintStreamTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/io/CapturedPrintStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright 2020-2023 Terracotta, Inc., a Software AG company.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,85 +15,254 @@
  */
 package org.terracotta.utilities.io;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.terracotta.org.junit.rules.TemporaryFolder;
 
 import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.PrintStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.Locale;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.terracotta.utilities.test.matchers.ThrowsMatcher.threw;
 
 /**
  * Basic tests for {@link CapturedPrintStream}.
  */
+@RunWith(Enclosed.class)
 public class CapturedPrintStreamTest {
 
-  @Test
-  public void testEmpty() throws Exception {
-    BufferedReader reader = CapturedPrintStream.getInstance().getReader();
-    assertThat(reader.readLine(), is(nullValue()));
-  }
+  public static class NonParameterizedTests {
+    @Test
+    public void testNullFile() {
+      assertThat(() -> CapturedPrintStream.getInstance(null), threw(instanceOf(NullPointerException.class)));
+      assertThat(() -> CapturedPrintStream.getInstance(null, false), threw(instanceOf(NullPointerException.class)));
+    }
 
-  @Test
-  public void testNoLineEnd() throws Exception {
-    CapturedPrintStream stream = CapturedPrintStream.getInstance();
-    stream.print("foo");
-    BufferedReader reader = stream.getReader();
-    assertThat(reader.readLine(), is("foo"));
-    assertThat(reader.readLine(), is(nullValue()));
-  }
+    @Test
+    public void testPrintStreamDelegate() throws IOException {
+      PrintStream delegate = mock(PrintStream.class);
+      CapturedPrintStream testInstance = CapturedPrintStream.getInstance();
+      testInstance.swapDelegate(delegate);
 
-  @Test
-  public void testTwoLines() throws Exception {
-    CapturedPrintStream stream = CapturedPrintStream.getInstance();
-    stream.println("foo");
-    stream.println("bar");
-    BufferedReader reader = stream.getReader();
-    assertThat(reader.readLine(), is("foo"));
-    assertThat(reader.readLine(), is("bar"));
-    assertThat(reader.readLine(), is(nullValue()));
-  }
+      testInstance.flush();
+      verify(delegate).flush();
 
-  @Test
-  public void testReset() throws Exception {
-    try (CapturedPrintStream stream = CapturedPrintStream.getInstance()) {
-      stream.print("abcdefghijklmno");
-      try (BufferedReader reader = stream.getReader()) {
-        assertThat(reader.readLine(), is("abcdefghijklmno"));
-      }
-      try (BufferedReader reader = stream.getReader()) {
-        assertThat(reader.readLine(), is("abcdefghijklmno"));
-      }
+      testInstance.close();
+      verify(delegate).close();
 
-      stream.reset();
-      try (BufferedReader reader = stream.getReader()) {
-        assertThat(reader.readLine(), is(nullValue()));
-      }
+      testInstance.checkError();
+      verify(delegate).checkError();
 
-      stream.println("content");
-      stream.reset();
-      stream.println("new content");
-      try (BufferedReader reader = stream.getReader()) {
-        assertThat(reader.readLine(), is("new content"));
-      }
+      testInstance.write(17);
+      verify(delegate).write(17);
+
+      byte[] bytes = new byte[0];
+      testInstance.write(bytes, 5, 18);
+      verify(delegate).write(bytes, 5, 18);
+
+      testInstance.print(true);
+      verify(delegate).print(true);
+
+      testInstance.print('D');
+      verify(delegate).print('D');
+
+      testInstance.print(27);
+      verify(delegate).print(27);
+
+      testInstance.print(2414682040998L);   // Dedekind 7
+      verify(delegate).print(2414682040998L);
+
+      testInstance.print(1.61803398874989484820d);   // Golden Ratio
+      verify(delegate).print(1.61803398874989484820d);
+
+      char[] charArray = "reveal".toCharArray();
+      testInstance.print(charArray);
+      verify(delegate).print(charArray);
+
+      testInstance.print("nonsense");
+      verify(delegate).print("nonsense");
+
+      Object o = new Object();
+      testInstance.print(o);
+      verify(delegate).print(o);
+
+      testInstance.println();
+      verify(delegate).println();
+
+      testInstance.println(true);
+      verify(delegate).println(true);
+
+      testInstance.println('D');
+      verify(delegate).println('D');
+
+      testInstance.println(27);
+      verify(delegate).println(27);
+
+      testInstance.println(2414682040998L);   // Dedekind 7
+      verify(delegate).println(2414682040998L);
+
+      testInstance.println(1.61803398874989484820d);   // Golden Ratio
+      verify(delegate).println(1.61803398874989484820d);
+
+      testInstance.println(charArray);
+      verify(delegate).println(charArray);
+
+      testInstance.println("nonsense");
+      verify(delegate).println("nonsense");
+
+      testInstance.println(o);
+      verify(delegate).println(o);
+
+      testInstance.printf("%d", 83);
+      verify(delegate).printf("%d", 83);
+
+      testInstance.printf(Locale.ROOT, "%d", 97);
+      verify(delegate).printf(Locale.ROOT, "%d", 97);
+
+      testInstance.format("%d", 83);
+      verify(delegate).format("%d", 83);
+
+      testInstance.format(Locale.ROOT, "%d", 97);
+      verify(delegate).format(Locale.ROOT, "%d", 97);
+
+      testInstance.append("sequence");
+      verify(delegate).append("sequence");
+
+      testInstance.append("string", 4, 6);
+      verify(delegate).append("string", 4, 6);
+
+      testInstance.append('C');
+      verify(delegate).append('C');
+
+      testInstance.write(bytes);
+      verify(delegate).write(bytes);
     }
   }
 
-  @Test
-  public void testToByteArray() {
-    try (CapturedPrintStream stream = CapturedPrintStream.getInstance()) {
-      String quote = "Now is the time for all good men to come to the aid of their country.";
-      stream.println(quote);
+  @RunWith(Parameterized.class)
+  public static class ParameterizedTests {
 
-      ByteBuffer buffer = StandardCharsets.UTF_8.encode(quote + System.lineSeparator());
-      byte[] expected = new byte[buffer.limit()];
-      buffer.get(expected);
-      assertThat(stream.toByteArray(), is(expected));
+    public enum Case {
+      MEMORY {
+        @Override
+        public CapturedPrintStream getCaptureStream(ParameterizedTests test) {
+          return CapturedPrintStream.getInstance();
+        }
+      },
+      FILE_BACKED {
+        @Override
+        public CapturedPrintStream getCaptureStream(ParameterizedTests test) throws IOException {
+          return CapturedPrintStream.getInstance(test.folder.newFile(test.testName.getMethodName()).toPath());
+        }
+      },
+      FILE_BACKED_NO_AUTOFLUSH {
+        @Override
+        public CapturedPrintStream getCaptureStream(ParameterizedTests test) throws IOException {
+          return CapturedPrintStream.getInstance(test.folder.newFile(test.testName.getMethodName()).toPath(), false);
+        }
+      };
 
-      stream.reset();
-      assertThat(stream.toByteArray(), is(new byte[0]));
+      public abstract CapturedPrintStream getCaptureStream(ParameterizedTests test) throws Exception;
+    }
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Case> data() {
+      return EnumSet.allOf(Case.class);
+    }
+
+    @Rule
+    public final TemporaryFolder folder = new TemporaryFolder();
+
+    @Rule
+    public final TestName testName = new TestName();
+
+    @Parameterized.Parameter
+    public Case testCase;
+
+    @Test
+    public void testEmpty() throws Exception {
+      try (CapturedPrintStream captureStream = testCase.getCaptureStream(this)) {
+        BufferedReader reader = captureStream.getReader();
+        assertThat(reader.readLine(), is(nullValue()));
+      }
+    }
+
+    @Test
+    public void testNoLineEnd() throws Exception {
+      try (CapturedPrintStream stream = testCase.getCaptureStream(this)) {
+        stream.print("foo");
+        BufferedReader reader = stream.getReader();
+        assertThat(reader.readLine(), is("foo"));
+        assertThat(reader.readLine(), is(nullValue()));
+      }
+    }
+
+    @Test
+    public void testTwoLines() throws Exception {
+      try (CapturedPrintStream stream = testCase.getCaptureStream(this)) {
+        stream.println("foo");
+        stream.println("bar");
+        BufferedReader reader = stream.getReader();
+        assertThat(reader.readLine(), is("foo"));
+        assertThat(reader.readLine(), is("bar"));
+        assertThat(reader.readLine(), is(nullValue()));
+      }
+    }
+
+    @Test
+    public void testReset() throws Exception {
+      try (CapturedPrintStream stream = testCase.getCaptureStream(this)) {
+        stream.print("abcdefghijklmno");
+        try (BufferedReader reader = stream.getReader()) {
+          assertThat(reader.readLine(), is("abcdefghijklmno"));
+        }
+        try (BufferedReader reader = stream.getReader()) {
+          assertThat(reader.readLine(), is("abcdefghijklmno"));
+        }
+
+        stream.reset();
+        try (BufferedReader reader = stream.getReader()) {
+          assertThat(reader.readLine(), is(nullValue()));
+        }
+
+        stream.println("content");
+        stream.reset();
+        stream.println("new content");
+        try (BufferedReader reader = stream.getReader()) {
+          assertThat(reader.readLine(), is("new content"));
+        }
+      }
+    }
+
+    @Test
+    public void testToByteArray() throws Exception {
+      try (CapturedPrintStream stream = testCase.getCaptureStream(this)) {
+        String quote = "Now is the time for all good men to come to the aid of their country.";
+        stream.println(quote);
+
+        ByteBuffer buffer = StandardCharsets.UTF_8.encode(quote + System.lineSeparator());
+        byte[] expected = new byte[buffer.limit()];
+        buffer.get(expected);
+        assertThat(stream.toByteArray(), is(expected));
+
+        stream.reset();
+        assertThat(stream.toByteArray(), is(new byte[0]));
+      }
     }
   }
 }


### PR DESCRIPTION
This commit adds AbstractRepeatingTest to support repeatedly running a specific or group of tests, suppressing test output, until the test fails or the repetition count is exhausted.

In addition, support is added to CapturedPrintStream for a file-backed buffer.