### PR TITLE
gradle: releaser - publish relationship

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,4 +45,13 @@ release {
     }
     versionProperties.set(listOf("defaultVersion"))
     tagTemplate.set("v\${version}")
+
+    // work around this issue by tacking on "build" again:
+    // https://github.com/researchgate/gradle-release/blob/af4bf46b/src/main/groovy/net/researchgate/release/ReleasePlugin.groovy#L153
+    buildTasks.set(listOf("build", "publish", "build"))
+    if (project.hasProperty("postReleaseBuildTasks")) {
+        // specify what to do after tagging/building and before updating to a SNAPSHOT version, eg:
+        // ./gradlew release -PpostReleaseBuildTasks="closeSonatypeStagingRepository"
+        buildTasks.addAll((project.property("postReleaseBuildTasks") as String).split(" "))
+    }
 }


### PR DESCRIPTION
The goal is to have the following do most of the work:
```bash 
 ./gradlew release -Prelease.useAutomaticVersion=true -PpostReleaseBuildTasks="closeSonatypeStagingRepository"
```

1. tag (remove -SNAPSHOT)
2. build/test
3. publish tag to sonatype
4. close sonatype repo
5. move to next snapshot / commit

This **does not push tag or snapshot increment commit**.    I expect to make that a step in the job unless someone has a different opinion.