### PR TITLE
Enable building & testing with Java 21

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
       image: almalinux:latest
     strategy:
       matrix:
-        java: [ 8, 11, 17 ]
+        java: [ 8, 11, 17, 21 ]
         distribution: [ zulu ]
       fail-fast: false
       max-parallel: 4
@@ -63,7 +63,7 @@ jobs:
       options: --user 1001:1001
     strategy:
       matrix:
-        java: [ 8, 11, 17 ]
+        java: [ 8, 11, 17, 21 ]
         distribution: [ zulu ]
       fail-fast: false
       max-parallel: 4
@@ -99,7 +99,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macOS-latest, windows-latest ]
-        java: [ 8, 11, 17 ]
+        java: [ 8, 11, 17, 21 ]
         distribution: [ zulu ]
       fail-fast: false
       max-parallel: 4

--- a/buildSrc/src/main/kotlin/org.terracotta.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/org.terracotta.java-conventions.gradle.kts
@@ -112,7 +112,8 @@ tasks {
         options.encoding = "UTF-8"
         options.isDeprecation = true
         options.isWarnings = true
-        options.compilerArgs.addAll(listOf("-Xlint:all", "-Werror"))
+        // '-Xlint:options' needed to ignore warning about source/target Java 8 obsolescence
+        options.compilerArgs.addAll(listOf("-Xlint:all", "-Xlint:-options", "-Werror"))
     }
 
     withType<Javadoc> {
@@ -142,6 +143,19 @@ tasks {
             register("html") {
                 required.set(true)
             }
+        }
+    }
+
+    spotbugsMain {
+        val spotbugsLastCheckLevel = JavaVersion.VERSION_21     // Most current Java version assessed for Spotbugs support
+        val spotbugsSuppressionLevel = JavaVersion.VERSION_21   // Java version at which Spotbugs is suppressed
+        if (JavaVersion.current() > spotbugsLastCheckLevel) {
+            throw GradleException("Current version of Java exceeds Spotbugs suppression level; re-examine Spotbugs suppression", null)
+        } else if (JavaVersion.current() >= spotbugsSuppressionLevel) {
+            logger.warn("Suppressing Spotbugs; current Java Version ${JavaVersion.current()} >= Spotbugs support version ${spotbugsSuppressionLevel}")
+            enabled = false
+        } else {
+            enabled = true
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ defaultVersion=0.0.19-SNAPSHOT
 #   gradle release (or: gradle release -Prelease.useAutomaticVersion=true)
 version=0.0.19-SNAPSHOT
 
-spotbugsAnnotationsVersion=4.0.2
+spotbugsAnnotationsVersion=4.8.3
 
 slf4jBaseVersion=1.7.32
 slf4jUpperVersion=1.7.9999

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -145,7 +145,7 @@ if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
     case $MAX_FD in #(
       max*)
         # In POSIX sh, ulimit -H is undefined. That's why the result is checked to see if it worked.
-        # shellcheck disable=SC3045
+        # shellcheck disable=SC2039,SC3045
         MAX_FD=$( ulimit -H -n ) ||
             warn "Could not query maximum file descriptor limit"
     esac
@@ -153,7 +153,7 @@ if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
       '' | soft) :;; #(
       *)
         # In POSIX sh, ulimit -n is undefined. That's why the result is checked to see if it worked.
-        # shellcheck disable=SC3045
+        # shellcheck disable=SC2039,SC3045
         ulimit -n "$MAX_FD" ||
             warn "Could not set maximum file descriptor limit to $MAX_FD"
     esac
@@ -202,11 +202,11 @@ fi
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
 DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 
-# Collect all arguments for the java command;
-#   * $DEFAULT_JVM_OPTS, $JAVA_OPTS, and $GRADLE_OPTS can contain fragments of
-#     shell script including quotes and variable substitutions, so put them in
-#     double quotes to make sure that they get re-expanded; and
-#   * put everything else in single quotes, so that it's not re-expanded.
+# Collect all arguments for the java command:
+#   * DEFAULT_JVM_OPTS, JAVA_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
+#     and any embedded shellness will be escaped.
+#   * For example: A user cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
+#     treated as '${Hostname}' itself on the command line.
 
 set -- \
         "-Dorg.gradle.appname=$APP_BASE_NAME" \

--- a/port-chooser/src/main/java/org/terracotta/utilities/test/net/NetStat.java
+++ b/port-chooser/src/main/java/org/terracotta/utilities/test/net/NetStat.java
@@ -15,6 +15,7 @@
  */
 package org.terracotta.utilities.test.net;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terracotta.utilities.exec.Shell;
@@ -1599,11 +1600,13 @@ public class NetStat {
       this.result = null;
     }
 
+    @SuppressFBWarnings("EI_EXPOSE_REP2")
     public HostExecutionException(String command, Shell.Result result, Throwable cause) {
       super(message(command, result), cause);
       this.result = result;
     }
 
+    @SuppressFBWarnings("EI_EXPOSE_REP2")
     public HostExecutionException(String command, Shell.Result result) {
       super(message(command, result));
       this.result = result;


### PR DESCRIPTION
This commit introduces Java 21 into the build/test matrix and  changes code to avoid compilation faults arising from Java 17+ changes.