### PR TITLE
Add IBM copyright notice

### DIFF
--- a/buildSrc/src/main/kotlin/org/terracotta/utilities/plugins/PlantUmlPlugin.kt
+++ b/buildSrc/src/main/kotlin/org/terracotta/utilities/plugins/PlantUmlPlugin.kt
@@ -1,17 +1,18 @@
 /*
- *  Copyright 2023 Terracotta, Inc., a Software AG company.
+ * Copyright 2023 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.terracotta.utilities.plugins
 

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   Copyright 2020 Terracotta, Inc., a Software AG company.
+  Copyright Super iPaaS Integration LLC, an IBM Company 2024
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/port-chooser/src/main/java/org/terracotta/utilities/test/io/CommonFiles.java
+++ b/port-chooser/src/main/java/org/terracotta/utilities/test/io/CommonFiles.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/port-chooser/src/main/java/org/terracotta/utilities/test/io/WindowsSpecialFolder.java
+++ b/port-chooser/src/main/java/org/terracotta/utilities/test/io/WindowsSpecialFolder.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/port-chooser/src/main/java/org/terracotta/utilities/test/net/EphemeralPorts.java
+++ b/port-chooser/src/main/java/org/terracotta/utilities/test/net/EphemeralPorts.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/port-chooser/src/main/java/org/terracotta/utilities/test/net/NetStat.java
+++ b/port-chooser/src/main/java/org/terracotta/utilities/test/net/NetStat.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020-2022 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/port-chooser/src/main/java/org/terracotta/utilities/test/net/PortManager.java
+++ b/port-chooser/src/main/java/org/terracotta/utilities/test/net/PortManager.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020-2023 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/port-chooser/src/main/java/org/terracotta/utilities/test/net/ReservedPorts.java
+++ b/port-chooser/src/main/java/org/terracotta/utilities/test/net/ReservedPorts.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/port-chooser/src/main/java/org/terracotta/utilities/test/net/SystemLevelLocker.java
+++ b/port-chooser/src/main/java/org/terracotta/utilities/test/net/SystemLevelLocker.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/port-chooser/src/main/java/org/terracotta/utilities/test/runtime/Os.java
+++ b/port-chooser/src/main/java/org/terracotta/utilities/test/runtime/Os.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/port-chooser/src/test/bin/netstat.sh
+++ b/port-chooser/src/test/bin/netstat.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 #
 # Copyright 2020-2023 Terracotta, Inc., a Software AG company.
+# Copyright Super iPaaS Integration LLC, an IBM Company 2024
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/port-chooser/src/test/java/org/terracotta/utilities/test/io/CommonFilesTest.java
+++ b/port-chooser/src/test/java/org/terracotta/utilities/test/io/CommonFilesTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/port-chooser/src/test/java/org/terracotta/utilities/test/net/EphemeralPortsTest.java
+++ b/port-chooser/src/test/java/org/terracotta/utilities/test/net/EphemeralPortsTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/port-chooser/src/test/java/org/terracotta/utilities/test/net/NetStatTest.java
+++ b/port-chooser/src/test/java/org/terracotta/utilities/test/net/NetStatTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020-2022 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/port-chooser/src/test/java/org/terracotta/utilities/test/net/PortManagerTest.java
+++ b/port-chooser/src/test/java/org/terracotta/utilities/test/net/PortManagerTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020-2022 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/port-chooser/src/test/java/org/terracotta/utilities/test/net/TestSupport.java
+++ b/port-chooser/src/test/java/org/terracotta/utilities/test/net/TestSupport.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020-2022 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/port-chooser/src/test/resources/logback-test.xml
+++ b/port-chooser/src/test/resources/logback-test.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   Copyright 2020 Terracotta, Inc., a Software AG company.
+  Copyright Super iPaaS Integration LLC, an IBM Company 2024
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/test-tools/config/checkstyle/suppressions.xml
+++ b/test-tools/config/checkstyle/suppressions.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   Copyright 2020 Terracotta, Inc., a Software AG company.
+  Copyright Super iPaaS Integration LLC, an IBM Company 2024
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/test-tools/config/spotbugs/excludeFilter.xml
+++ b/test-tools/config/spotbugs/excludeFilter.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   Copyright 2020 Terracotta, Inc., a Software AG company.
+  Copyright Super iPaaS Integration LLC, an IBM Company 2024
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/test-tools/src/main/java/org/terracotta/utilities/test/AbstractRepeatingRunListener.java
+++ b/test-tools/src/main/java/org/terracotta/utilities/test/AbstractRepeatingRunListener.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2023 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-tools/src/main/java/org/terracotta/utilities/test/AbstractRepeatingTest.java
+++ b/test-tools/src/main/java/org/terracotta/utilities/test/AbstractRepeatingTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2023-2024 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-tools/src/main/java/org/terracotta/utilities/test/ByteCodeVersion.java
+++ b/test-tools/src/main/java/org/terracotta/utilities/test/ByteCodeVersion.java
@@ -1,17 +1,18 @@
 /*
- *  Copyright 2023 Terracotta, Inc., a Software AG company.
+ * Copyright 2023 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.terracotta.utilities.test;
 

--- a/test-tools/src/main/java/org/terracotta/utilities/test/Diagnostics.java
+++ b/test-tools/src/main/java/org/terracotta/utilities/test/Diagnostics.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-tools/src/main/java/org/terracotta/utilities/test/ModuleSupport.java
+++ b/test-tools/src/main/java/org/terracotta/utilities/test/ModuleSupport.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2023 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-tools/src/main/java/org/terracotta/utilities/test/TerracottaAssert.java
+++ b/test-tools/src/main/java/org/terracotta/utilities/test/TerracottaAssert.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-tools/src/main/java/org/terracotta/utilities/test/WaitForAssert.java
+++ b/test-tools/src/main/java/org/terracotta/utilities/test/WaitForAssert.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-tools/src/main/java/org/terracotta/utilities/test/logging/ConsoleAppenderCapture.java
+++ b/test-tools/src/main/java/org/terracotta/utilities/test/logging/ConsoleAppenderCapture.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-tools/src/main/java/org/terracotta/utilities/test/matchers/Eventually.java
+++ b/test-tools/src/main/java/org/terracotta/utilities/test/matchers/Eventually.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-tools/src/main/java/org/terracotta/utilities/test/matchers/Matchers.java
+++ b/test-tools/src/main/java/org/terracotta/utilities/test/matchers/Matchers.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-tools/src/main/java/org/terracotta/utilities/test/matchers/OptionalMatcher.java
+++ b/test-tools/src/main/java/org/terracotta/utilities/test/matchers/OptionalMatcher.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-tools/src/main/java/org/terracotta/utilities/test/matchers/PrimitiveArrayMatching.java
+++ b/test-tools/src/main/java/org/terracotta/utilities/test/matchers/PrimitiveArrayMatching.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-tools/src/main/java/org/terracotta/utilities/test/matchers/SequenceMatcher.java
+++ b/test-tools/src/main/java/org/terracotta/utilities/test/matchers/SequenceMatcher.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-tools/src/main/java/org/terracotta/utilities/test/matchers/ThrowableCauseMatcher.java
+++ b/test-tools/src/main/java/org/terracotta/utilities/test/matchers/ThrowableCauseMatcher.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-tools/src/main/java/org/terracotta/utilities/test/matchers/ThrowsMatcher.java
+++ b/test-tools/src/main/java/org/terracotta/utilities/test/matchers/ThrowsMatcher.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-tools/src/main/java/org/terracotta/utilities/test/rules/TestRetryer.java
+++ b/test-tools/src/main/java/org/terracotta/utilities/test/rules/TestRetryer.java
@@ -1,11 +1,12 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test-tools/src/test/java/org/terracotta/utilities/test/DiagnosticsTest.java
+++ b/test-tools/src/test/java/org/terracotta/utilities/test/DiagnosticsTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-tools/src/test/java/org/terracotta/utilities/test/SampleRepeatingTest.java
+++ b/test-tools/src/test/java/org/terracotta/utilities/test/SampleRepeatingTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2023 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-tools/src/test/java/org/terracotta/utilities/test/WaitForAssertTest.java
+++ b/test-tools/src/test/java/org/terracotta/utilities/test/WaitForAssertTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-tools/src/test/java/org/terracotta/utilities/test/logging/ConsoleAppenderCaptureNoConsoleTest.java
+++ b/test-tools/src/test/java/org/terracotta/utilities/test/logging/ConsoleAppenderCaptureNoConsoleTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-tools/src/test/java/org/terracotta/utilities/test/logging/ConsoleAppenderCaptureTest.java
+++ b/test-tools/src/test/java/org/terracotta/utilities/test/logging/ConsoleAppenderCaptureTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-tools/src/test/java/org/terracotta/utilities/test/matchers/EventuallyTest.java
+++ b/test-tools/src/test/java/org/terracotta/utilities/test/matchers/EventuallyTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-tools/src/test/java/org/terracotta/utilities/test/matchers/ThrowableCauseMatcherTest.java
+++ b/test-tools/src/test/java/org/terracotta/utilities/test/matchers/ThrowableCauseMatcherTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-tools/src/test/java/org/terracotta/utilities/test/matchers/ThrowsMatcherTest.java
+++ b/test-tools/src/test/java/org/terracotta/utilities/test/matchers/ThrowsMatcherTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-tools/src/test/java/org/terracotta/utilities/test/rules/TestRetryerTest.java
+++ b/test-tools/src/test/java/org/terracotta/utilities/test/rules/TestRetryerTest.java
@@ -1,11 +1,12 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test-tools/src/test/resources/noConsoleAppender.xml
+++ b/test-tools/src/test/resources/noConsoleAppender.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   Copyright 2022 Terracotta, Inc., a Software AG company.
+  Copyright Super iPaaS Integration LLC, an IBM Company 2024
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/tools/src/main/java/org/terracotta/utilities/classloading/CustomLoaderBasedObjectInputStream.java
+++ b/tools/src/main/java/org/terracotta/utilities/classloading/CustomLoaderBasedObjectInputStream.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/src/main/java/org/terracotta/utilities/classloading/FilteredObjectInputStream.java
+++ b/tools/src/main/java/org/terracotta/utilities/classloading/FilteredObjectInputStream.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/src/main/java/org/terracotta/utilities/exec/Shell.java
+++ b/tools/src/main/java/org/terracotta/utilities/exec/Shell.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/src/main/java/org/terracotta/utilities/io/CapturedPrintStream.java
+++ b/tools/src/main/java/org/terracotta/utilities/io/CapturedPrintStream.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020-2023 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/src/main/java/org/terracotta/utilities/io/Files.java
+++ b/tools/src/main/java/org/terracotta/utilities/io/Files.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/src/main/java/org/terracotta/utilities/io/FilesSupport.java
+++ b/tools/src/main/java/org/terracotta/utilities/io/FilesSupport.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/src/main/java/org/terracotta/utilities/io/NullOutputStream.java
+++ b/tools/src/main/java/org/terracotta/utilities/io/NullOutputStream.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/src/main/java/org/terracotta/utilities/io/buffer/DumpUtility.java
+++ b/tools/src/main/java/org/terracotta/utilities/io/buffer/DumpUtility.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020-2023 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/src/main/java/org/terracotta/utilities/logging/LoggerBridge.java
+++ b/tools/src/main/java/org/terracotta/utilities/logging/LoggerBridge.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/src/main/java/org/terracotta/utilities/logging/LoggingOutputStream.java
+++ b/tools/src/main/java/org/terracotta/utilities/logging/LoggingOutputStream.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/src/main/java/org/terracotta/utilities/memory/MemoryInfo.java
+++ b/tools/src/main/java/org/terracotta/utilities/memory/MemoryInfo.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2024 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/src/test/java/org/terracotta/utilities/concurrent/InterprocessCyclicBarrier.java
+++ b/tools/src/test/java/org/terracotta/utilities/concurrent/InterprocessCyclicBarrier.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/src/test/java/org/terracotta/utilities/concurrent/InterprocessCyclicBarrierTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/concurrent/InterprocessCyclicBarrierTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/src/test/java/org/terracotta/utilities/io/CapturedPrintStreamTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/io/CapturedPrintStreamTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020-2023 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/src/test/java/org/terracotta/utilities/io/FilesCopyTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/io/FilesCopyTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/src/test/java/org/terracotta/utilities/io/FilesCreateTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/io/FilesCreateTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022-2023 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/src/test/java/org/terracotta/utilities/io/FilesDeleteTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/io/FilesDeleteTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/src/test/java/org/terracotta/utilities/io/FilesDeleteTreeTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/io/FilesDeleteTreeTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/src/test/java/org/terracotta/utilities/io/FilesEnvironmentTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/io/FilesEnvironmentTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/src/test/java/org/terracotta/utilities/io/FilesRelocateDirectorySymlinkTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/io/FilesRelocateDirectorySymlinkTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/src/test/java/org/terracotta/utilities/io/FilesRelocateDirectoryTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/io/FilesRelocateDirectoryTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/src/test/java/org/terracotta/utilities/io/FilesRelocateFileSymlinkTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/io/FilesRelocateFileSymlinkTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/src/test/java/org/terracotta/utilities/io/FilesRelocateFileTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/io/FilesRelocateFileTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/src/test/java/org/terracotta/utilities/io/FilesRelocateTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/io/FilesRelocateTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/src/test/java/org/terracotta/utilities/io/FilesRelocateTestBase.java
+++ b/tools/src/test/java/org/terracotta/utilities/io/FilesRelocateTestBase.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/src/test/java/org/terracotta/utilities/io/FilesRenameTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/io/FilesRenameTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/src/test/java/org/terracotta/utilities/io/FilesStreamCopyTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/io/FilesStreamCopyTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/src/test/java/org/terracotta/utilities/io/FilesSupportTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/io/FilesSupportTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/src/test/java/org/terracotta/utilities/io/FilesTestBase.java
+++ b/tools/src/test/java/org/terracotta/utilities/io/FilesTestBase.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020-2022 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/src/test/java/org/terracotta/utilities/io/NullOutputStreamTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/io/NullOutputStreamTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/src/test/java/org/terracotta/utilities/io/buffer/AbstractDumpUtilityTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/io/buffer/AbstractDumpUtilityTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2023 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/src/test/java/org/terracotta/utilities/io/buffer/DumpUtilityArrayTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/io/buffer/DumpUtilityArrayTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2023 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/src/test/java/org/terracotta/utilities/io/buffer/DumpUtilityTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/io/buffer/DumpUtilityTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2023 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/src/test/java/org/terracotta/utilities/logging/LoggerBridgeTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/logging/LoggerBridgeTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/src/test/java/org/terracotta/utilities/logging/LoggingOutputStreamTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/logging/LoggingOutputStreamTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/src/test/java/org/terracotta/utilities/memory/MemoryInfoTest.java
+++ b/tools/src/test/java/org/terracotta/utilities/memory/MemoryInfoTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2024 Terracotta, Inc., a Software AG company.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/src/test/resources/logback-test.xml
+++ b/tools/src/test/resources/logback-test.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   Copyright 2020 Terracotta, Inc., a Software AG company.
+  Copyright Super iPaaS Integration LLC, an IBM Company 2024
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.


### PR DESCRIPTION
A few files had some spacing changes -- all are normalized now.  Most just add the IBM line.

The following IntelliJ IDEA template was used for the update:

```plain
$originalComment.match("(Copyright .* a Software AG company\.)")
Copyright Super iPaaS Integration LLC, an IBM Company $originalComment.match("Copyright .* an IBM Company (\d+)", 1, ",")$today.year

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

     http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
```

In this template, the first line _retains_ the original copyright line.  The second line adds/updates the IBM copyright line.